### PR TITLE
fix: barcode_to_accumulated_persistence verbose default should be False

### DIFF
--- a/masspcf/persistence/barcode_summary.py
+++ b/masspcf/persistence/barcode_summary.py
@@ -110,7 +110,7 @@ def barcode_to_betti_curve(
 def barcode_to_accumulated_persistence(
     bc: Barcode | BarcodeTensor,
     max_death: float = float("inf"),
-    verbose: bool = True,
+    verbose: bool = False,
 ):
     r"""Convert barcodes to accumulated persistence functions.
 


### PR DESCRIPTION
Fixes issue #30. The function signature declared `verbose: bool = True` but the docstring, sibling functions, and Sphinx docs all document `False` as the default. This caused unexpected tqdm progress bar output on default calls.