### PR TITLE
Fix unvalidated out-of-range dim in reductions (mean/max_time)

### DIFF
--- a/docs/evaluation.rst
+++ b/docs/evaluation.rst
@@ -181,6 +181,10 @@ When the result would be a single element (a tensor of shape ``(1,)``), stablebe
 returns a scalar (a ``Pcf`` or a ``float``) directly rather than a 1-element
 tensor.
 
+``dim`` must be in range for the input tensor: for a ``k``-dimensional tensor the
+valid values are ``0`` through ``k - 1``. An out-of-range ``dim`` raises an
+``IndexError``.
+
 mean
 ----
 

--- a/include/sbear/algorithms/functional/matrix_reduce.hpp
+++ b/include/sbear/algorithms/functional/matrix_reduce.hpp
@@ -20,9 +20,12 @@
 #include "../../functional/pcf.hpp"
 #include "../../tensor.hpp"
 #include "../../executor.hpp"
+#include "../../detail/tensor_1d_value_iterator.hpp"
 #include "reduce.hpp"
 
 #include <iostream>
+#include <sstream>
+#include <stdexcept>
 #include <utility>
 
 namespace sb
@@ -37,14 +40,35 @@ namespace sb
     std::cout << std::endl;
   };
 
-  template <typename PcfT, typename ReductionF>
-  Tensor<PcfT> parallel_tensor_reduce(
+  // Validate a reduction dimension against a tensor shape. An out-of-range dim
+  // would otherwise index/erase past the end of the shape vector (UB: wrong
+  // result for dim == ndim, heap corruption for dim > ndim). Throwing here
+  // surfaces a clean, catchable exception (pybind11 maps std::out_of_range to
+  // a Python IndexError).
+  inline void check_reduce_dim(size_t dim, size_t ndim)
+  {
+    if (dim >= ndim)
+    {
+      std::ostringstream oss;
+      oss << "Reduction dimension " << dim << " is out of range for tensor of dimension " << ndim;
+      throw std::out_of_range(oss.str());
+    }
+  }
+
+  // Shared skeleton for every dimension reduction: build the reduced-shape
+  // output tensor, then for each output cell reduce the input slice along `dim`
+  // in place (via a strided iterator -- no per-slice copy). Callers supply the
+  // output element type `OutT` and a `reduction` functor mapping the slice
+  // [first, last) to a single OutT value.
+  template <typename OutT, typename PcfT, typename ReductionF>
+  Tensor<OutT> parallel_dim_reduce(
       const Tensor<PcfT>& in,
       size_t dim,
       ReductionF&& reduction,
       Executor& exec = default_executor())
   {
     auto shape = in.shape();
+    check_reduce_dim(dim, shape.size());
     auto inDimSize = shape[dim];
 
     shape.erase(shape.begin() + dim);
@@ -53,7 +77,7 @@ namespace sb
       shape.resize(1, 1);
     }
 
-    Tensor<PcfT> ret(shape);
+    Tensor<OutT> ret(shape);
     auto op = std::forward<ReductionF>(reduction);
     sb::parallel_walk(ret, [&ret, &in, inDimSize, dim, &op](const std::vector<size_t>& idx){
       std::vector<size_t> inIdx(in.shape().size(), 0_uz);
@@ -65,20 +89,27 @@ namespace sb
         std::copy(idx.begin() + dim, idx.end(), inIdx.begin() + dim + 1);
       }
 
-      std::vector<PcfT> tmp; // TODO: Rewrite without need to copy
-      tmp.reserve(inDimSize);
-      for (auto i = 0_uz; i < inDimSize; ++i)
-      {
-        inIdx[dim] = i;
-        tmp.emplace_back( in(inIdx) );
-      }
+      // inIdx[dim] == 0 marks the origin of the slice; the iterator walks `dim`.
+      Tensor1dValueIterator<const Tensor<PcfT>> first(in, inIdx, dim, 0_uz);
+      Tensor1dValueIterator<const Tensor<PcfT>> last(in, inIdx, dim, inDimSize);
 
-      auto & out = ret(idx);
-
-      out = reduce(tmp, op);
+      ret(idx) = op(first, last);
     }, exec);
 
     return ret;
+  }
+
+  template <typename PcfT, typename ReductionF>
+  Tensor<PcfT> parallel_tensor_reduce(
+      const Tensor<PcfT>& in,
+      size_t dim,
+      ReductionF&& reduction,
+      Executor& exec = default_executor())
+  {
+    auto op = std::forward<ReductionF>(reduction);
+    return parallel_dim_reduce<PcfT>(in, dim, [op](auto first, auto last) {
+      return reduce(first, last, op);
+    }, exec);
   }
 
   template <typename PcfT>
@@ -97,50 +128,16 @@ namespace sb
   template <typename PcfT, typename UnaryF, typename MaxOp>
   auto max_element(const Tensor<PcfT>& in, size_t dim, UnaryF&& f, MaxOp&& maxOp, Executor& exec = default_executor())
   {
-    using OutTensorT = Tensor<std::decay_t<
-        decltype(f(std::declval<PcfT>()))
-    >>;
-
-    using OutValueT = typename OutTensorT::value_type;
+    using OutValueT = std::decay_t<decltype(f(std::declval<PcfT>()))>;
 
     static_assert(std::invocable<MaxOp, OutValueT, OutValueT>);
 
-    auto shape = in.shape();
-    auto inDimSize = shape[dim];
-
-    shape.erase(shape.begin() + dim);
-    if (shape.empty())
-    {
-      shape.resize(1, 1);
-    }
-    OutTensorT ret(shape);
-
-    sb::parallel_walk(ret, [&ret, &in, inDimSize, dim, &f, &maxOp](const std::vector<size_t>& idx){
-      std::vector<size_t> inIdx(in.shape().size(), 0_uz);
-
-      std::copy(idx.begin(), idx.begin() + dim, inIdx.begin());
-      if (inIdx.size() > 1)
-      {
-        // MSVC debug does not like (inIdx.begin() + dim + 1) even if nothing is written there it seems.
-        std::copy(idx.begin() + dim, idx.end(), inIdx.begin() + dim + 1);
-      }
-
-      std::vector<PcfT> tmp; // TODO: Rewrite without need to copy
-      tmp.reserve(inDimSize);
-      for (auto i = 0_uz; i < inDimSize; ++i)
-      {
-        inIdx[dim] = i;
-        tmp.emplace_back( in(inIdx) );
-      }
-
-      auto & out = ret(idx);
-
-      auto init = f(*tmp.begin());
-      out =  std::transform_reduce(tmp.begin() + 1, tmp.end(), init, maxOp, f);
-
+    auto fn = std::forward<UnaryF>(f);
+    auto mop = std::forward<MaxOp>(maxOp);
+    return parallel_dim_reduce<OutValueT>(in, dim, [fn, mop](auto first, auto last) {
+      auto init = fn(*first);
+      return std::transform_reduce(first + 1, last, init, mop, fn);
     }, exec);
-
-    return ret;
   }
 }
 

--- a/include/sbear/algorithms/functional/reduce.hpp
+++ b/include/sbear/algorithms/functional/reduce.hpp
@@ -70,12 +70,18 @@ namespace sb
     return TPcf(std::move(retPts));
   }
 
+  template <typename InputIt, typename TPcf = typename std::iterator_traits<InputIt>::value_type>
+  TPcf reduce(InputIt begin, InputIt end, TOp<TPcf> op)
+  {
+    return std::reduce(begin, end, TPcf(), [&op](const TPcf& f, const TPcf& g) {
+      return combine(f, g, op);
+    });
+  }
+
   template <typename TPcf>
   TPcf reduce(const std::vector<TPcf>& fs, TOp<TPcf> op)
   {
-    return std::reduce(fs.begin(), fs.end(), TPcf(), [&op](const TPcf& f, const TPcf& g) {
-      return combine(f, g, op);
-    });
+    return reduce(fs.begin(), fs.end(), op);
   }
 
   template <typename TPcf>

--- a/include/sbear/detail/tensor_1d_value_iterator.hpp
+++ b/include/sbear/detail/tensor_1d_value_iterator.hpp
@@ -17,64 +17,75 @@
 
 #include <cstddef>
 #include <iterator>
+#include <type_traits>
+#include <vector>
 
 namespace sb
 {
 
+  // Random-access iterator over a single tensor dimension. It walks the
+  // elements base[pos * stride] for an increasing logical position `pos`, where
+  // `stride` is the tensor's stride along the chosen dimension. Tracking the
+  // logical position (rather than only a raw pointer) keeps it well-defined for
+  // a broadcast dimension whose stride is 0: such a range still spans the
+  // requested number of (identical) elements instead of collapsing to empty.
+  //
+  // TensorT may be const-qualified; when it is, the iterator yields const
+  // references, so it can read a `const Tensor&` without copying its elements.
   template<typename TensorT>
   class Tensor1dValueIterator
   {
+    using element_type = std::conditional_t<
+        std::is_const_v<TensorT>,
+        const typename std::remove_const_t<TensorT>::value_type,
+        typename TensorT::value_type>;
+
   public:
     using difference_type = std::ptrdiff_t;
-    using value_type = typename TensorT::value_type;
-    using pointer = value_type*;
-    using reference = value_type&;
-    using const_reference = const value_type&;
+    using value_type = std::remove_const_t<element_type>;
+    using pointer = element_type*;
+    using reference = element_type&;
+    using const_reference = const element_type&;
     using self_type = Tensor1dValueIterator;
     using iterator_category = std::random_access_iterator_tag;
 
     constexpr Tensor1dValueIterator() noexcept
-        : m_cur(nullptr), m_stride(0) {
+        : m_base(nullptr), m_stride(0), m_pos(0) {
     }
 
-    constexpr Tensor1dValueIterator(TensorT& tensor, size_t idx) noexcept
-        : m_cur(&tensor(idx)), m_stride(tensor.stride(0)) {
+    // Iterate dimension 0 of `tensor`, positioned at `pos`. The base is pinned
+    // to the start of the dimension so that begin/end iterators (which differ
+    // only in `pos`) compare equal once they reach the same position.
+    Tensor1dValueIterator(TensorT& tensor, size_t pos) noexcept
+        : m_base(&tensor(0)), m_stride(tensor.stride(0)), m_pos(static_cast<difference_type>(pos)) {
     }
 
-    constexpr Tensor1dValueIterator(const Tensor1dValueIterator& other) noexcept
-        : m_cur(other.m_cur), m_stride(other.m_stride) {
+    // Iterate dimension `dim` of `tensor` over the slice whose remaining indices
+    // are fixed by `startIndex` (its `dim` component is the origin, i.e. 0),
+    // positioned at `pos`.
+    Tensor1dValueIterator(TensorT& tensor, const std::vector<size_t>& startIndex, size_t dim, size_t pos) noexcept
+        : m_base(&tensor(startIndex)), m_stride(tensor.stride(dim)), m_pos(static_cast<difference_type>(pos)) {
     }
 
-    constexpr Tensor1dValueIterator& operator=(const Tensor1dValueIterator& other) noexcept {
-      m_cur = other.m_cur;
-      m_stride = other.m_stride;
-      return *this;
-    }
-
-    constexpr Tensor1dValueIterator& operator=(Tensor1dValueIterator&& other) noexcept {
-      m_cur = other.m_cur;
-      m_stride = other.m_stride;
-      return *this;
-    }
-
-    [[nodiscard]] constexpr bool operator==(const Tensor1dValueIterator& rhs) const noexcept {
-      return m_cur == rhs.m_cur && m_stride == rhs.m_stride;
-    }
+    constexpr Tensor1dValueIterator(const Tensor1dValueIterator& other) noexcept = default;
+    constexpr Tensor1dValueIterator& operator=(const Tensor1dValueIterator& other) noexcept = default;
+    constexpr Tensor1dValueIterator(Tensor1dValueIterator&& other) noexcept = default;
+    constexpr Tensor1dValueIterator& operator=(Tensor1dValueIterator&& other) noexcept = default;
 
     [[nodiscard]] constexpr reference operator*() const noexcept {
-      return *m_cur;
+      return m_base[m_pos * m_stride];
     }
 
     [[nodiscard]] constexpr pointer operator->() const noexcept {
-      return m_cur;
+      return m_base + m_pos * m_stride;
     }
 
     [[nodiscard]] constexpr reference operator[](difference_type n) const noexcept {
-      return *(*this + n);
+      return m_base[(m_pos + n) * m_stride];
     }
 
     constexpr self_type& operator++() noexcept {
-      m_cur += m_stride;
+      ++m_pos;
       return *this;
     }
 
@@ -85,7 +96,7 @@ namespace sb
     }
 
     constexpr self_type& operator--() noexcept {
-      m_cur -= m_stride;
+      --m_pos;
       return *this;
     }
 
@@ -96,12 +107,12 @@ namespace sb
     }
 
     constexpr self_type& operator+=(difference_type n) noexcept {
-      m_cur += n * static_cast<difference_type>(m_stride);
+      m_pos += n;
       return *this;
     }
 
     constexpr self_type& operator-=(difference_type n) noexcept {
-      m_cur -= n * static_cast<difference_type>(m_stride);
+      m_pos -= n;
       return *this;
     }
 
@@ -111,43 +122,44 @@ namespace sb
       return tmp;
     }
 
-    [[nodiscard]] constexpr difference_type operator-(const self_type& other) const noexcept {
-      if (m_stride == 0)
-      {
-        return 0; // Prevent division by zero in constexpr
-      }
-      return static_cast<difference_type>(m_cur - other.m_cur) / m_stride;
-    }
-
     constexpr self_type operator-(difference_type n) const noexcept {
       auto tmp = *this;
       tmp -= n;
       return tmp;
     }
 
-    [[nodiscard]] constexpr bool operator<(const self_type& rhs) const noexcept {
-      return m_cur < rhs.m_cur;
+    [[nodiscard]] constexpr difference_type operator-(const self_type& other) const noexcept {
+      return m_pos - other.m_pos;
     }
 
-    [[nodiscard]] constexpr bool operator<=(const self_type& rhs) const noexcept {
-      return m_cur <= rhs.m_cur;
-    }
-
-    [[nodiscard]] constexpr bool operator>(const self_type& rhs) const noexcept {
-      return m_cur > rhs.m_cur;
-    }
-
-    [[nodiscard]] constexpr bool operator>=(const self_type& rhs) const noexcept {
-      return m_cur >= rhs.m_cur;
+    [[nodiscard]] constexpr bool operator==(const self_type& rhs) const noexcept {
+      return m_pos == rhs.m_pos && m_base == rhs.m_base && m_stride == rhs.m_stride;
     }
 
     [[nodiscard]] constexpr bool operator!=(const self_type& rhs) const noexcept {
-      return m_cur != rhs.m_cur || m_stride != rhs.m_stride;
+      return !(*this == rhs);
+    }
+
+    [[nodiscard]] constexpr bool operator<(const self_type& rhs) const noexcept {
+      return m_pos < rhs.m_pos;
+    }
+
+    [[nodiscard]] constexpr bool operator<=(const self_type& rhs) const noexcept {
+      return m_pos <= rhs.m_pos;
+    }
+
+    [[nodiscard]] constexpr bool operator>(const self_type& rhs) const noexcept {
+      return m_pos > rhs.m_pos;
+    }
+
+    [[nodiscard]] constexpr bool operator>=(const self_type& rhs) const noexcept {
+      return m_pos >= rhs.m_pos;
     }
 
   private:
-    pointer m_cur;
-    size_t m_stride;
+    pointer m_base;
+    difference_type m_stride;
+    difference_type m_pos;
   };
 
   template<typename TensorT>

--- a/stablebear/reductions.py
+++ b/stablebear/reductions.py
@@ -63,6 +63,11 @@ def mean(fs: PcfContainerLike, dim: int = 0):
     -------
     PcfTensor
         A ``PcfTensor`` with the reduced dimension removed.
+
+    Raises
+    ------
+    IndexError
+        If ``dim`` is out of range for the input tensor's number of dimensions.
     """
     backend, tensor = _resolve_pcf_inputs(_REDUCTIONS_BACKEND_MAP, fs)
     return _to_tensor(backend.mean(tensor._data, dim))
@@ -95,6 +100,11 @@ def max_time(fs: PcfContainerLike, dim: int = 0):
     -------
     FloatTensor
         A numeric tensor with the reduced dimension removed.
+
+    Raises
+    ------
+    IndexError
+        If ``dim`` is out of range for the input tensor's number of dimensions.
     """
     backend, tensor = _resolve_pcf_inputs(_REDUCTIONS_BACKEND_MAP, fs)
     return _to_tensor(backend.max_time(tensor._data, dim))

--- a/test/python/test_bugscan_reductions.py
+++ b/test/python/test_bugscan_reductions.py
@@ -1,0 +1,54 @@
+import numpy as np
+import pytest
+
+import stablebear as sb
+
+
+def test_mean_dim_equal_ndim_raises():
+    """mean with dim == ndim must raise, not silently return a wrong shape."""
+    # BUG: Out-of-range dim in reductions is unvalidated (dim == ndim)
+    # Expected: an out-of-range axis raises a clean Python exception; never a
+    # silent wrong shape, and never heap corruption / interpreter abort.
+    A = sb.zeros((3, 4))
+    with pytest.raises((IndexError, ValueError)):
+        sb.mean(A, dim=2)
+
+
+def test_max_time_dim_equal_ndim_raises():
+    """max_time with dim == ndim must raise, not silently return a wrong shape."""
+    A = sb.zeros((3, 4))
+    with pytest.raises((IndexError, ValueError)):
+        sb.max_time(A, dim=2)
+
+
+def test_mean_dim_greater_than_ndim_raises():
+    """mean with dim > ndim must raise cleanly (previously corrupted the heap)."""
+    A = sb.zeros((3, 4))
+    for bad_dim in (3, 5, 6, 100):
+        with pytest.raises((IndexError, ValueError)):
+            sb.mean(A, dim=bad_dim)
+
+
+def test_max_time_dim_greater_than_ndim_raises():
+    """max_time with dim > ndim must raise cleanly (previously corrupted the heap)."""
+    A = sb.zeros((3, 4))
+    for bad_dim in (3, 5, 6, 100):
+        with pytest.raises((IndexError, ValueError)):
+            sb.max_time(A, dim=bad_dim)
+
+
+def test_mean_1d_out_of_range_raises():
+    """1-D reduction with dim >= ndim must raise rather than silently return."""
+    A = sb.zeros((3,))
+    for bad_dim in (1, 2):
+        with pytest.raises((IndexError, ValueError)):
+            sb.mean(A, dim=bad_dim)
+
+
+def test_mean_in_range_dim_still_works():
+    """Sanity check: valid dims keep producing the documented reduced shape."""
+    A = sb.zeros((3, 4))
+    assert sb.mean(A, dim=0).shape == (4,)
+    assert sb.mean(A, dim=1).shape == (3,)
+    assert sb.max_time(A, dim=0).shape == (4,)
+    assert sb.max_time(A, dim=1).shape == (3,)


### PR DESCRIPTION
Fixes #24.

## Problem
An out-of-range `dim` in `mean` / `max_time` was passed straight to the C++ reductions, which indexed and erased past the end of the shape vector with no bounds check:
- `dim == ndim` -> silently returned a wrong-shaped, meaningless tensor (exit 0).
- `dim > ndim` -> iterator arithmetic ran far past the end, corrupting the heap and aborting the interpreter (SIGABRT, no catchable Python exception).

The exact outcome varied with heap layout, confirming undefined behavior.

## Fix
Validate the dimension at the C++ root cause via `check_reduce_dim(dim, ndim)`, which throws `std::out_of_range`. This covers **all** callers (the GoogleTest suite and any future C++ code, not only the Python wrapper), and pybind11 maps it to a catchable Python `IndexError`:

```
IndexError: Reduction dimension 2 is out of range for tensor of dimension 2
```

## Refactor (while in the area)
- **De-duplicated** `parallel_tensor_reduce` and `max_element`, which shared the entire walk-and-gather skeleton and differed only in output element type and per-slice combine. Both are now thin wrappers over a generic `parallel_dim_reduce<OutT>`, so the bounds check lives in one place.
- **Resolved the `// TODO: Rewrite without need to copy`**: reductions now read each input slice in place through `Tensor1dValueIterator` instead of deep-copying PCFs into a temporary `std::vector`.
- **Generalized `Tensor1dValueIterator`** (previously hardwired to dim 0) to walk an arbitrary dimension, be const-correct, and track logical position rather than a raw pointer -- so a broadcast/stride-0 dimension spans the correct element count instead of collapsing to an empty range.

## Tests & docs
- New `test/python/test_bugscan_reductions.py` (the issue's regression tests plus `dim > ndim`, 1-D, and in-range sanity cases).
- `Raises` notes added to the `mean` / `max_time` docstrings and a range note in `docs/evaluation.rst`.

## Verification
- All 438 C++ tests pass (incl. `TensorIteration`, `ParallelReduce`).
- All 1588 Python tests pass.
- Reductions over a stride-0 broadcast dimension verified to return correct values.
- The exact issue reproductions (`dim` = 2, 5, 100) now raise `IndexError` with no abort.