### PR TITLE
Validate enumeration bounds in from_serial_content (#37)

### DIFF
--- a/src/python/functional/py_make_from_serial_content.cpp
+++ b/src/python/functional/py_make_from_serial_content.cpp
@@ -78,10 +78,15 @@ namespace sb_py
       auto start = *(enumerationBuf + enumerationBaseOffset);
       auto stop = *(enumerationBuf + enumerationBaseOffset + lastStride);
 
-      // TODO: Throw if stop <= start
       if (start >= stop)
       {
         throw py::value_error("Item in index " + sb::index_to_string(idx) + " in the enumeration has start >= stop (" + std::to_string(start) + " >= " + std::to_string(stop) + ")");
+      }
+
+      auto numRows = static_cast<detail::EnumerationDt>(content.shape(0));
+      if (start < 0 || stop > numRows)
+      {
+        throw py::value_error("Item in index " + sb::index_to_string(idx) + " in the enumeration is out of range for content with " + std::to_string(numRows) + " rows (start=" + std::to_string(start) + ", stop=" + std::to_string(stop) + "); requires 0 <= start < stop <= " + std::to_string(numRows) + ".");
       }
 
       std::vector<PointT> pts;

--- a/test/python/test_from_serial_content.py
+++ b/test/python/test_from_serial_content.py
@@ -91,6 +91,41 @@ def test_fsc_stop_le_start_throws():
         X = sb.from_serial_content(content, enumeration)
 
 
+@pytest.mark.parametrize("dtype", [np.float64, np.float32])
+def test_fsc_stop_overflow_raises(dtype):
+    """stop beyond content length must raise cleanly, not read OOB heap memory.
+
+    Regression for #37: stop > content.shape(0) was unchecked, so the loop read
+    past the content buffer and returned uninitialized heap garbage (small
+    overflow) or segfaulted (large overflow), exit 0 / no exception.
+    """
+    content = np.array([[0.0, 1.0], [2.0, 3.0]], dtype=dtype)
+    enumeration = np.array([[0, 20]], dtype=np.int64)
+    with pytest.raises((ValueError, IndexError)):
+        sb.from_serial_content(content, enumeration)
+
+
+@pytest.mark.parametrize("dtype", [np.float64, np.float32])
+def test_fsc_negative_start_raises(dtype):
+    """Negative start bypassed the start>=stop guard and read negative offsets.
+
+    Regression for #37 case (C): enum [[-1000, 1]] satisfied start < stop yet
+    read OOB; it must raise.
+    """
+    content = np.array([[0.0, 1.0], [2.0, 3.0]], dtype=dtype)
+    enumeration = np.array([[-1000, 1]], dtype=np.int64)
+    with pytest.raises((ValueError, IndexError)):
+        sb.from_serial_content(content, enumeration)
+
+
+def test_fsc_stop_equals_length_ok():
+    """stop == content.shape(0) is in-bounds and must still succeed."""
+    content = np.array([[0.0, 10.0], [10.0, 20.0], [20.0, 30.0]])
+    enumeration = np.array([[0, 3]])
+    X = sb.from_serial_content(content, enumeration)
+    assert X[0] == sb.Pcf(content[0:3])
+
+
 def test_fsc_dtypes():
     content32 = np.array(
         [[0.0, 10.0], [10.0, 20.0], [20.0, 30.0], [0.0, 50.0], [10.0, 60.0]],


### PR DESCRIPTION
Fixes #37.

## Problem

`make_from_serial_content` only guarded `start >= stop`. It never checked that the enumeration's `start`/`stop` fall within the content buffer, then looped `i in [start, stop)` calling `get_element`, which does raw pointer arithmetic (`base_ptr + offset`) with no bounds check. On user-supplied (e.g. corrupted/untrusted serialized) input this read out of bounds:

- **(A) small overflow** -- `content (2,2)` + enum `[[0,20]]` returned a `(20,2)` Pcf whose extra rows were uninitialized heap memory; exit 0, no exception.
- **(B) large overflow** -- `content (1,2)` + enum `[[0,10**7]]` segfaulted the interpreter (exit 139), no traceback.
- **(C) negative start** -- enum `[[-1000,1]]` slipped past the `start >= stop` guard (`-1000 < 1`) and read negative offsets; exit 0.

Both the pcf32 and pcf64 paths were affected.

## Fix

`src/python/functional/py_make_from_serial_content.cpp` -- after the existing `start >= stop` check, validate `0 <= start < stop <= content.shape(0)` per enumeration entry and raise a clean `ValueError` on violation (also removed the stale `// TODO: Throw if stop <= start` comment).

## Tests

Added to `test/python/test_from_serial_content.py`, following the repo's `pytest.raises` convention:
- `test_fsc_stop_overflow_raises` (float64 + float32) -- case (A)
- `test_fsc_negative_start_raises` (float64 + float32) -- case (C)
- `test_fsc_stop_equals_length_ok` -- `stop == length` is in-bounds and still succeeds

Verified the former-segfault case (B) now raises `ValueError` cleanly. All existing `from_serial_content` tests stay green.