### PR TITLE
Fix segfault in max_time/plot on empty tensor (#46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.3
+
+### Bug fixes
+
+* **`max_time` and `plotting.plot` no longer segfault on an empty tensor** — reducing an empty PcfTensor (or any tensor whose reduction dimension has size 0) with `max_time` crashed the interpreter, because `max_element` seeded the reduction from the first element of an empty range and reduced past-the-end iterators. `max` has no identity over an empty range, so `max_time` now raises a catchable `ValueError` (mirroring NumPy's zero-size reduction error), and `plotting.plot` — which calls `max_time` internally — degrades to a graceful no-op when there is nothing to draw. ([#46](https://github.com/kthtda/stablebear/issues/46))
+
 ## 0.4.2
 
 * masspcf is now stablebear.

--- a/include/sbear/algorithms/functional/matrix_reduce.hpp
+++ b/include/sbear/algorithms/functional/matrix_reduce.hpp
@@ -132,6 +132,21 @@ namespace sb
 
     static_assert(std::invocable<MaxOp, OutValueT, OutValueT>);
 
+    // max has no identity element, so it cannot reduce an empty range: the
+    // body below seeds from *first and reduces [first + 1, last), both UB when
+    // the slice is empty (inDimSize == 0). Reject up front with a clean,
+    // catchable exception (pybind11 maps std::invalid_argument to a Python
+    // ValueError) instead of dereferencing a past-the-end iterator -- mirrors
+    // numpy's "zero-size array to reduction operation" error. Validate dim
+    // first so shape[dim] is in range.
+    check_reduce_dim(dim, in.shape().size());
+    if (in.shape()[dim] == 0)
+    {
+      std::ostringstream oss;
+      oss << "Cannot reduce an empty dimension: dimension " << dim << " has size 0";
+      throw std::invalid_argument(oss.str());
+    }
+
     auto fn = std::forward<UnaryF>(f);
     auto mop = std::forward<MaxOp>(maxOp);
     return parallel_dim_reduce<OutValueT>(in, dim, [fn, mop](auto first, auto last) {

--- a/stablebear/plotting.py
+++ b/stablebear/plotting.py
@@ -63,6 +63,11 @@ def plot(f: PcfContainerLike, fmt="", ax=None, auto_label=False, max_time=None, 
             if len(squeezed.shape) != 1:
                 raise ValueError(f"Expected 1-dimensional array (got array with {f.shape})")
             return plot(squeezed, ax=ax, max_time=max_time, auto_label=auto_label, **kwargs)
+        if f.shape[0] == 0:
+            # Nothing to plot: an empty tensor has no PCFs. Bail out before
+            # reducing with max_time, which has no identity over an empty range
+            # and would otherwise raise on the (vacuous) reduction.
+            return
         mt = max_time if max_time is not None else float(max_time_reduction(f))
         for i in range(f.shape[0]):
             kw = {"label": f"f{i}"} if auto_label else {}

--- a/stablebear/reductions.py
+++ b/stablebear/reductions.py
@@ -105,6 +105,9 @@ def max_time(fs: PcfContainerLike, dim: int = 0):
     ------
     IndexError
         If ``dim`` is out of range for the input tensor's number of dimensions.
+    ValueError
+        If the reduction dimension is empty (size 0). ``max`` has no identity
+        over an empty range, so there is no value to return.
     """
     backend, tensor = _resolve_pcf_inputs(_REDUCTIONS_BACKEND_MAP, fs)
     return _to_tensor(backend.max_time(tensor._data, dim))

--- a/test/python/test_bugscan_interop.py
+++ b/test/python/test_bugscan_interop.py
@@ -1,0 +1,40 @@
+import matplotlib
+
+matplotlib.use("Agg")
+
+import pytest
+
+import stablebear as sb
+import stablebear.plotting as plotting
+from stablebear.reductions import max_time
+
+
+def test_max_time_empty_raises_valueerror():
+    """max_time on an empty reduction dimension raises ValueError, not SIGSEGV."""
+    # BUG (#46): max_time() segfaulted on an empty PcfTensor -- max_element
+    # seeded the reduction from *begin() of an empty range (UB). Expected: a
+    # clean Python exception, mirroring numpy's zero-size reduction error.
+    with pytest.raises(ValueError):
+        max_time(sb.PcfTensor([]))
+
+
+def test_max_time_empty_dim_of_higher_rank_raises():
+    """An empty reduction dimension in a higher-rank tensor also raises cleanly."""
+    A = sb.PcfTensor(sb.zeros((3, 0)))
+    with pytest.raises(ValueError):
+        max_time(A, dim=1)
+
+
+def test_max_time_reduces_nonempty_dim_with_empty_sibling():
+    """Reducing a non-empty dim is fine even when another dim is empty."""
+    # shape (0, 4) reduced along the size-4 dim yields an empty (0,) result --
+    # there are no slices to reduce, so this must not hit the empty-range guard.
+    A = sb.PcfTensor(sb.zeros((0, 4)))
+    assert max_time(A, dim=1).shape == (0,)
+
+
+def test_plot_empty_is_graceful_noop():
+    """plotting.plot on an empty PcfTensor is a graceful no-op, not a crash."""
+    # BUG (#46): plotting.plot() reached max_time internally and segfaulted.
+    # Expected: nothing to draw, so plot returns without raising.
+    plotting.plot(sb.PcfTensor([]))


### PR DESCRIPTION
Fixes #46.

## Problem
`max_time()` and `plotting.plot()` hard-crashed (SIGSEGV) on an empty `PcfTensor` — a valid, benign container reachable from documented public API. `max_element` (in `matrix_reduce.hpp`) seeded its reduction from `*first` and reduced `[first + 1, last)` with no empty check, so when the reduction dimension has size 0 both iterators are past-the-end (UB). `mean` was unaffected because it uses an identity-seeded `reduce`.

## Fix
`max` has no identity over an empty range, so:

- **`max_element`** now validates `dim` and rejects an empty reduction dimension with `std::invalid_argument`, which pybind11 maps to a Python `ValueError` (mirroring NumPy's "zero-size array to reduction operation"). Reducing a *non-empty* dim that merely has an empty sibling dim still works and yields an empty result.
- **`plotting.plot`** bails out early when there is nothing to draw, so an empty tensor degrades to a graceful no-op instead of reaching `max_time`.
- Documented the new `ValueError` contract in the `max_time` docstring.

## Tests
New regression tests in `test/python/test_bugscan_interop.py`:
- `max_time` on an empty tensor raises `ValueError` (1-D and higher-rank empty dim)
- reducing a non-empty dim with an empty sibling dim works
- `plot` on an empty tensor is a graceful no-op

All affected suites pass (`test_bugscan_interop`, `test_bugscan_reductions`, `test_reduction`, `test_plotting`).