### PR TITLE
Accept ndarray RHS in tensor arithmetic operators (#62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug fixes
 
 * **`max_time` and `plotting.plot` no longer segfault on an empty tensor** — reducing an empty PcfTensor (or any tensor whose reduction dimension has size 0) with `max_time` crashed the interpreter, because `max_element` seeded the reduction from the first element of an empty range and reduced past-the-end iterators. `max` has no identity over an empty range, so `max_time` now raises a catchable `ValueError` (mirroring NumPy's zero-size reduction error), and `plotting.plot` — which calls `max_time` internally — degrades to a graceful no-op when there is nothing to draw. ([#46](https://github.com/kthtda/stablebear/issues/46))
+* **`tensor + ndarray` no longer raises a raw `TypeError`** — the reflected form `ndarray + tensor` worked (via `__radd__`), but the forward `tensor + ndarray` passed the array straight through to C++ and raised a bare pybind `TypeError`, a surprising asymmetry. The forward operators now wrap an ndarray (or list/tuple) right-hand side as a same-type tensor, casting to the tensor's dtype, so `+`, `-`, `*`, `/` and their in-place variants are symmetric. ([#62](https://github.com/kthtda/stablebear/issues/62))
 
 ## 0.4.2
 

--- a/stablebear/_tensor_base.py
+++ b/stablebear/_tensor_base.py
@@ -835,7 +835,16 @@ class ArithmeticTensorMixin:
     """
 
     def _decay_operand(self, val):
-        return val._data if hasattr(val, "_data") else val
+        if hasattr(val, "_data"):
+            return val._data
+        import numpy as np
+        if isinstance(val, (np.ndarray, list, tuple)):
+            # Wrap an array-like RHS as a same-type tensor (cast to this
+            # tensor's dtype where applicable) so that ``tensor + array``
+            # mirrors ``array + tensor``. See issue #62.
+            wrapped = self._coerce_rhs(type(self)(val))
+            return wrapped._data
+        return val
 
     def __add__(self, rhs):
         return self._to_py_tensor(self._data + self._decay_operand(rhs))

--- a/test/python/test_ndarray_arithmetic.py
+++ b/test/python/test_ndarray_arithmetic.py
@@ -1,0 +1,81 @@
+#  Copyright 2024-2026 Bjorn Wehlin
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""Regression tests for issue #62: ``tensor + ndarray`` used to raise a
+pybind ``TypeError`` even though ``ndarray + tensor`` worked, an asymmetry
+that surprised users. The forward operators should now accept an ndarray
+(or list/tuple) RHS and behave like the reflected ones."""
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+import stablebear as sb
+
+
+_BINOPS = [
+    pytest.param(lambda x, y: x + y, id="add"),
+    pytest.param(lambda x, y: x - y, id="sub"),
+    pytest.param(lambda x, y: x * y, id="mul"),
+    pytest.param(lambda x, y: x / y, id="truediv"),
+]
+
+
+@pytest.mark.parametrize("op", _BINOPS)
+def test_forward_and_reflected_each_match_numpy(op):
+    """Both directions must match numpy: previously only the reflected
+    direction (arr + f) worked while the forward (f + arr) crashed. The
+    forward op must also preserve the tensor type rather than decay to an
+    ndarray."""
+    np_a = np.array([1.0, 2.0, 3.0])
+    arr = np.array([10.0, 20.0, 30.0])
+    f = sb.FloatTensor(np_a)
+    forward = op(f, arr)
+    assert isinstance(forward, sb.FloatTensor)
+    npt.assert_allclose(np.asarray(forward), op(np_a, arr))
+    npt.assert_allclose(np.asarray(op(arr, f)), op(arr, np_a))
+
+
+def test_forward_ndarray_broadcasts():
+    np_a = np.array([[1.0, 2.0], [3.0, 4.0]])
+    arr = np.array([10.0, 20.0])
+    f = sb.FloatTensor(np_a)
+    npt.assert_allclose(np.asarray(f + arr), np_a + arr)
+
+
+def test_list_rhs():
+    np_a = np.array([1.0, 2.0, 3.0])
+    f = sb.FloatTensor(np_a)
+    npt.assert_allclose(np.asarray(f + [10.0, 20.0, 30.0]), np_a + np.array([10.0, 20.0, 30.0]))
+
+
+def test_inplace_add_ndarray():
+    np_a = np.array([1.0, 2.0, 3.0])
+    arr = np.array([10.0, 20.0, 30.0])
+    f = sb.FloatTensor(np_a.copy())
+    f += arr
+    npt.assert_allclose(np.asarray(f), np_a + arr)
+
+
+def test_scalar_rhs_still_works():
+    np_a = np.array([1.0, 2.0, 3.0])
+    f = sb.FloatTensor(np_a)
+    npt.assert_allclose(np.asarray(f + 5), np_a + 5)
+
+
+def test_int_tensor_plus_ndarray():
+    np_a = np.array([1, 2, 3], dtype=np.int64)
+    arr = np.array([10, 20, 30], dtype=np.int64)
+    t = sb.IntTensor(np_a)
+    npt.assert_array_equal(np.asarray(t + arr), np_a + arr)


### PR DESCRIPTION
## Summary

Closes #62.

`numpy.ndarray + tensor` worked (numpy returns `NotImplemented` because
`__array_ufunc__ = None`, so Python routes to the tensor's `__radd__`), but
the forward direction `tensor + numpy.ndarray` raised a raw pybind
`TypeError` because the forward operators passed the ndarray straight to
C++. The two directions disagreed.

## Changes

- `stablebear/_tensor_base.py`: `ArithmeticTensorMixin._decay_operand` now
  wraps an `ndarray` (or `list`/`tuple`) RHS as a same-type tensor via
  `type(self)(val)`, casting to this tensor's dtype through the existing
  `_coerce_rhs` helper — the same wrap-as-tensor pattern `__setitem__`
  already uses. Scalars and `Tensor` operands are unchanged.

This makes `+`, `-`, `*`, `/` (and their in-place variants) symmetric with
respect to ndarray operands.

## Tests

New `test/python/test_ndarray_arithmetic.py` covers forward ndarray
operands for all four operators, that each direction matches numpy,
broadcasting, list RHS, in-place `+=`, scalar RHS, and IntTensor + ndarray.

Full Python suite passes (1588 passed, 31 skipped).

https://claude.ai/code/session_01TFzYr6tv1Tyu8u1aUYud4q

---
_Generated by [Claude Code](https://claude.ai/code/session_01TFzYr6tv1Tyu8u1aUYud4q)_