### PR TITLE
Mark bug-scan issue #25 (max_time empty-axis crash) resolved

### DIFF
--- a/test/python/test_bugscan_reductions.py
+++ b/test/python/test_bugscan_reductions.py
@@ -88,3 +88,23 @@ def test_out_of_range_dim_raises_index_error(bad_dim):
     for fn in (sb.mean, sb.max_time):
         with pytest.raises(IndexError):
             fn(A, dim=bad_dim)
+
+
+def test_max_time_empty_reduced_axis_raises_not_segfault():
+    """max_time over a size-0 reduced axis must raise cleanly, never SIGSEGV.
+
+    Issue #25 (bug scan): ``max_time`` segfaulted on an empty reduction
+    dimension while ``mean`` handled it. Resolved together with #46 —
+    ``max_element`` now rejects an empty reduction range with ``ValueError``
+    (``max`` has no identity over an empty range). ``mean`` still returns a
+    valid reduced tensor over the same empty axes, so the two stay consistent.
+    """
+    # 1-D empty tensor reduced along its only (empty) axis.
+    with pytest.raises(ValueError):
+        sb.max_time(sb.zeros((0,)), dim=0)
+    # Empty inner dimension of a higher-rank tensor.
+    with pytest.raises(ValueError):
+        sb.max_time(sb.zeros((3, 0)), dim=1)
+    # Contrast: mean returns a valid reduced tensor over the same empty axes.
+    assert sb.mean(sb.zeros((0,)), dim=0).shape == (1,)
+    assert sb.mean(sb.zeros((3, 0)), dim=1).shape == (3,)


### PR DESCRIPTION
## Summary

While triaging the open `bug` + `severity: high` issues, **#25** turned out to already be fixed on `dev`. It is the same root cause as **#46** ("max_time/plot segfault on empty tensor") and was resolved by that fix: `max_element` now rejects an empty reduction range with a catchable `ValueError` instead of dereferencing past-the-end iterators.

This PR marks #25 off:

- **CHANGELOG**: cross-references #25 on the existing #46 bug-fix entry (0.4.3), noting the exact size-0 reduced-axis reproductions.
- **Test**: adds an explicit #25 regression test mirroring the issue's reproduction, including the `mean` contrast the issue emphasises.

No production code changes — the behaviour is already correct on `dev`; this only records it and pins it with a dedicated test.

## Tests that show #25 is fixed

Run with `cd test && python -m pytest python/test_bugscan_reductions.py python/test_bugscan_interop.py`.

New, added here (exact #25 reproductions):
- `test/python/test_bugscan_reductions.py::test_max_time_empty_reduced_axis_raises_not_segfault`
  - `max_time(zeros((0,)), dim=0)` → raises `ValueError` (was SIGSEGV)
  - `max_time(zeros((3, 0)), dim=1)` → raises `ValueError` (was SIGSEGV)
  - `mean(zeros((0,)), dim=0).shape == (1,)` and `mean(zeros((3, 0)), dim=1).shape == (3,)` (the consistent, non-crashing contrast)

Pre-existing (from the #46 fix), also covering the behaviour:
- `test/python/test_bugscan_interop.py::test_max_time_empty_raises_valueerror`
- `test/python/test_bugscan_interop.py::test_max_time_empty_dim_of_higher_rank_raises`
- `test/python/test_bugscan_interop.py::test_max_time_reduces_nonempty_dim_with_empty_sibling`

All 11 tests in the two files pass.

Fixes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLUKg7KqfRzMq9A5VLr6pj)_