### PR TITLE
Copy overlapping RHS in assign_from (self-aliasing slice assignment)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug fixes
 
 * **A single point cloud is now subscriptable** — a 0-d `PointCloudTensor` (one cloud, e.g. `sb.PointCloudTensor(arr)` from an `(n_points, dim)` array) can be indexed as its underlying array, so the natural plotting idiom `pc[:, 0]` / `pc[:, 1]` works directly instead of raising `IndexError`. Indexing tensors of rank ≥ 1 still selects clouds as before. ([#133](https://github.com/kthtda/stablebear/issues/133))
+* **Self-aliasing slice assignment no longer corrupts data** — assigning an overlapping view of a tensor into itself (`a[:] = a[::-1]`, `a[1:] = a[:-1]`) silently produced wrong results, because the element-wise copy read positions it had already overwritten. The right-hand side is now materialized first when it overlaps the destination (matching NumPy), so `a[:] = a[::-1]` reverses correctly; non-overlapping assignments are unaffected. ([#6](https://github.com/kthtda/stablebear/issues/6))
 
 ## 0.4.3
 

--- a/include/sbear/tensor.tpp
+++ b/include/sbear/tensor.tpp
@@ -136,6 +136,26 @@ namespace sb
     }
 
     auto rhs_view = rhs.broadcast_to(target);
+
+    // If the RHS aliases this tensor's storage (e.g. a[:] = a[::-1] or
+    // a[1:] = a[:-1], where both sides are views of the same buffer), an
+    // element-wise walk would read positions it has already overwritten.
+    // Materialize an independent copy of the RHS first, matching NumPy's
+    // handling of overlapping assignment. Aliasing is only possible when the
+    // element types match and the two views share the same base buffer; data()
+    // includes the view offset, so compare the buffer base (data() - offset()).
+    if constexpr (std::is_same_v<T, U>)
+    {
+      if (this->data() - this->offset() == rhs.data() - rhs.offset())
+      {
+        Tensor<T> rhs_copy = rhs_view.copy();
+        sb::walk(*this, [this, &rhs_copy](const std::vector<size_t>& idx){
+          (*this)(idx) = rhs_copy(idx);
+        });
+        return;
+      }
+    }
+
     sb::walk(*this, [this, &rhs_view](const std::vector<size_t>& idx){
       (*this)(idx) = T(rhs_view(idx));
     });

--- a/test/python/test_bugscan_setitem.py
+++ b/test/python/test_bugscan_setitem.py
@@ -1,0 +1,64 @@
+import numpy as np
+
+import stablebear as sb
+
+
+# ---------------------------------------------------------------------------
+# Bug #6: self-aliasing basic-slice assignment (a[:] = a[::-1], a[1:] = a[:-1])
+# silently corrupted data, because Tensor::assign_from walked element-by-element
+# with no overlap handling and read back values it had already overwritten.
+# NumPy materializes an overlapping RHS into a temporary; match that.
+# ---------------------------------------------------------------------------
+
+
+def test_reverse_in_place_1d():
+    a = sb.FloatTensor(np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32))
+    a[:] = a[::-1]
+    na = np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32)
+    na[:] = na[::-1]
+    assert np.asarray(a).tolist() == na.tolist() == [4.0, 3.0, 2.0, 1.0]
+
+
+def test_shift_down_2d():
+    b = sb.FloatTensor(np.arange(12, dtype=np.float32).reshape(4, 3))
+    b[1:] = b[:-1]
+    nb = np.arange(12, dtype=np.float32).reshape(4, 3)
+    nb[1:] = nb[:-1]
+    assert np.array_equal(np.asarray(b), nb)
+
+
+def test_forward_overlap_1d():
+    a = sb.FloatTensor(np.arange(6, dtype=np.float64))
+    a[1:] = a[:-1]
+    na = np.arange(6, dtype=np.float64)
+    na[1:] = na[:-1]
+    assert np.asarray(a).tolist() == na.tolist() == [0.0, 0.0, 1.0, 2.0, 3.0, 4.0]
+
+
+def test_int_tensor_self_alias():
+    a = sb.IntTensor(np.array([1, 2, 3, 4], dtype=np.int64))
+    a[:] = a[::-1]
+    assert np.asarray(a).tolist() == [4, 3, 2, 1]
+
+
+def test_copy_rhs_control_still_correct():
+    c = sb.FloatTensor(np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32))
+    c[:] = c[::-1].copy()
+    assert np.asarray(c).tolist() == [4.0, 3.0, 2.0, 1.0]
+
+
+def test_non_aliased_assignment_unchanged():
+    d = sb.FloatTensor(np.array([1.0, 2.0, 3.0, 4.0]))
+    e = sb.FloatTensor(np.array([10.0, 20.0, 30.0, 40.0]))
+    d[:] = e[::-1]
+    assert np.asarray(d).tolist() == [40.0, 30.0, 20.0, 10.0]
+    assert np.asarray(e).tolist() == [10.0, 20.0, 30.0, 40.0]  # source untouched
+
+
+def test_partial_overlap_disjoint_halves():
+    """Same buffer, disjoint regions -- must still match numpy."""
+    a = sb.FloatTensor(np.arange(6, dtype=np.float64))
+    a[:3] = a[3:]
+    na = np.arange(6, dtype=np.float64)
+    na[:3] = na[3:]
+    assert np.asarray(a).tolist() == na.tolist()


### PR DESCRIPTION
## Summary

`Tensor::assign_from` walked the destination element-by-element (`(*this)(idx) = rhs_view(idx)`) with no overlap handling. When the RHS is a view of the **same** tensor, source and destination storage overlap, so the walk read back values it had already overwritten:

```python
a = FloatTensor(np.array([1., 2., 3., 4.]))
a[:] = a[::-1]      # was: [4, 3, 3, 4]   (numpy: [4, 3, 2, 1])
b[1:] = b[:-1]      # was: all rows equal to row 0
```

## Fix

When the RHS shares the destination's **base buffer**, materialize an independent copy of the RHS before the walk — matching NumPy, which copies an overlapping RHS into a temporary. Notes:
- Aliasing is only possible when element types match, so the check is under `if constexpr (std::is_same_v<T, U>)` (cross-dtype assignment, e.g. int→float, can't alias).
- `data()` includes the view offset, so `a[1:]` and `a[:-1]` have *different* `data()` pointers despite sharing a buffer — the base is compared via `data() - offset()`.
- Non-overlapping and cross-dtype assignments keep the original copy-free path.

## Tests

`test/python/test_bugscan_setitem.py`, all asserted against NumPy:
- `test_reverse_in_place_1d`, `test_shift_down_2d`, `test_forward_overlap_1d`
- `test_int_tensor_self_alias`, `test_copy_rhs_control_still_correct`
- `test_non_aliased_assignment_unchanged` (source untouched, copy-free path), `test_partial_overlap_disjoint_halves`

Full suites green: **404** C++ and **1644** Python tests pass (31 skipped).

Fixes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLUKg7KqfRzMq9A5VLr6pj)_