### PR TITLE
Deep-copy elements stored in point-cloud / matrix tensors (no aliasing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug fixes
 
 * **A single point cloud is now subscriptable** — a 0-d `PointCloudTensor` (one cloud, e.g. `sb.PointCloudTensor(arr)` from an `(n_points, dim)` array) can be indexed as its underlying array, so the natural plotting idiom `pc[:, 0]` / `pc[:, 1]` works directly instead of raising `IndexError`. Indexing tensors of rank ≥ 1 still selects clouds as before. ([#133](https://github.com/kthtda/stablebear/issues/133))
+* **Storing a matrix or point cloud in a tensor cell now copies it (no aliasing)** — assigning a `DistanceMatrix`, `SymmetricMatrix`, or point cloud into a tensor cell (`t[i] = m`) or slice (`t[0:2] = src`) now copies the element instead of sharing its buffer, so later mutation of the source (or assigning one object into several cells) no longer silently corrupts the stored cells. Matches NumPy object-array assignment. ([#39](https://github.com/kthtda/stablebear/issues/39))
 
 ## 0.4.3
 

--- a/include/sbear/distance_matrix.hpp
+++ b/include/sbear/distance_matrix.hpp
@@ -71,6 +71,16 @@ namespace sb
 
     DistanceMatrix() : DistanceMatrix(0) { }
 
+    /// Return an independent deep copy. The implicit copy shares the
+    /// std::shared_ptr buffer (view-like), which is relied on internally; this
+    /// is used when a matrix must not alias its source (e.g. a tensor cell).
+    [[nodiscard]] DistanceMatrix copy() const
+    {
+      DistanceMatrix result(m_size);
+      std::copy(m_data.get(), m_data.get() + storage_size(m_size), result.m_data.get());
+      return result;
+    }
+
     [[nodiscard]] size_t size() const { return m_size; }
     [[nodiscard]] size_t storage_count() const { return storage_size(m_size); }
 

--- a/include/sbear/symmetric_matrix.hpp
+++ b/include/sbear/symmetric_matrix.hpp
@@ -37,6 +37,16 @@ namespace sb
 
     SymmetricMatrix() : SymmetricMatrix(0) { }
 
+    /// Return an independent deep copy. The implicit copy shares the
+    /// std::shared_ptr buffer (view-like), which is relied on internally; this
+    /// is used when a matrix must not alias its source (e.g. a tensor cell).
+    [[nodiscard]] SymmetricMatrix copy() const
+    {
+      SymmetricMatrix result(m_size);
+      std::copy(m_data.get(), m_data.get() + storage_size(m_size), result.m_data.get());
+      return result;
+    }
+
     [[nodiscard]] size_t size() const { return m_size; }
     [[nodiscard]] size_t storage_count() const { return storage_size(m_size); }
 

--- a/include/sbear/tensor.hpp
+++ b/include/sbear/tensor.hpp
@@ -390,6 +390,23 @@ namespace sb
   template <ArithmeticType T>
   using PointCloud = Tensor<T>;
 
+  namespace detail
+  {
+    // Deep-copy a value about to be stored in a tensor cell, so the cell never
+    // aliases the source. Element types that hold a shared buffer (Tensor /
+    // PointCloud, DistanceMatrix, SymmetricMatrix) expose a deep copy() that is
+    // preferred; all other element types (float, Pcf, ...) already copy deeply
+    // by value, so they are returned unchanged.
+    template <typename T>
+    [[nodiscard]] T store_copy(const T& v)
+    {
+      if constexpr (requires { v.copy(); })
+        return v.copy();
+      else
+        return v;
+    }
+  }
+
   template <typename T, typename UnaryPred>
 #ifndef __CUDACC__
   requires std::invocable<UnaryPred, const T&>

--- a/include/sbear/tensor.tpp
+++ b/include/sbear/tensor.tpp
@@ -137,7 +137,9 @@ namespace sb
 
     auto rhs_view = rhs.broadcast_to(target);
     sb::walk(*this, [this, &rhs_view](const std::vector<size_t>& idx){
-      (*this)(idx) = T(rhs_view(idx));
+      // store_copy deep-copies element types that share a buffer (point clouds
+      // and the matrix types), so a slice assignment never aliases the source.
+      (*this)(idx) = detail::store_copy(T(rhs_view(idx)));
     });
   }
 

--- a/src/python/py_tensor.hpp
+++ b/src/python/py_tensor.hpp
@@ -221,7 +221,7 @@ namespace sb_py
 
       .def("_set_element", [](TTensor& self, const std::vector<size_t>& index, const T& val) {
           assert_valid_index(self, index);
-          self(index) = val;
+          self(index) = sb::detail::store_copy(val);
         })
 
       .def("copy", &TTensor::copy)

--- a/test/python/test_bugscan_element_assign.py
+++ b/test/python/test_bugscan_element_assign.py
@@ -1,0 +1,79 @@
+import numpy as np
+import pytest
+
+import stablebear as sb
+from stablebear.distance_matrix import DistanceMatrix
+from stablebear.symmetric_matrix import SymmetricMatrix
+
+
+# ---------------------------------------------------------------------------
+# Bug #39: element assignment into PointCloud / DistanceMatrix / SymmetricMatrix
+# tensors shared the source's std::shared_ptr buffer (a shallow copy), so cells
+# aliased the source object and each other. Storing an element must copy its
+# data (NumPy object-array .copy() semantics).
+# ---------------------------------------------------------------------------
+
+
+def test_distmat_cell_independent_of_source_after_assign():
+    t = sb.zeros((2,), dtype=sb.distmat64)
+    m = DistanceMatrix(3)
+    m[0, 1] = 2.0
+    t[0] = m
+    m[0, 2] = 8.0                       # mutate the source after assignment
+    assert t[0][0, 2] == 0.0           # cell not affected
+    assert t[0][0, 1] == 2.0           # value at assignment time is preserved
+
+
+@pytest.mark.parametrize(
+    "dt, mk",
+    [
+        pytest.param(sb.distmat64, lambda: DistanceMatrix(3), id="distmat"),
+        pytest.param(sb.symmat64, lambda: SymmetricMatrix(3), id="symmat"),
+    ],
+)
+def test_matrix_cells_from_same_source_are_independent(dt, mk):
+    t = sb.zeros((2,), dtype=dt)
+    shared = mk()
+    t[0] = shared
+    t[1] = shared
+    t[0][0, 1] = 99.0
+    assert t[0][0, 1] == 99.0          # the write landed on cell 0
+    assert t[1][0, 1] == 0.0           # sibling unaffected
+    assert shared[0, 1] == 0.0         # source unaffected
+
+
+def test_pcloud_cell_independent_of_source_and_sibling():
+    t = sb.zeros((2,), dtype=sb.pcloud64)
+    src = sb.FloatTensor(np.zeros((3, 2)))
+    t[0] = src
+    t[1] = src
+    t[0][0, 0] = 99.0
+    assert float(t[1][0, 0]) == 0.0    # sibling unaffected
+    assert float(src[0, 0]) == 0.0     # source FloatTensor unaffected
+
+
+@pytest.mark.parametrize(
+    "dt, mk",
+    [
+        pytest.param(sb.distmat64, lambda: DistanceMatrix(3), id="distmat"),
+        pytest.param(sb.symmat64, lambda: SymmetricMatrix(3), id="symmat"),
+    ],
+)
+def test_matrix_slice_assignment_is_independent(dt, mk):
+    t = sb.zeros((2,), dtype=dt)
+    srct = sb.zeros((2,), dtype=dt)
+    srct[0] = mk()
+    srct[1] = mk()
+    t[0:2] = srct
+    srct[0][0, 1] = 77.0               # mutate the source tensor's cell
+    assert t[0][0, 1] == 0.0
+
+
+def test_mutating_one_cell_leaves_others_untouched():
+    t = sb.zeros((3,), dtype=sb.distmat64)
+    for i in range(3):
+        t[i] = DistanceMatrix(3)
+    t[1][0, 1] = 5.0
+    assert t[0][0, 1] == 0.0
+    assert t[2][0, 1] == 0.0
+    assert t[1][0, 1] == 5.0


### PR DESCRIPTION
## Summary

`PointCloud` (`= Tensor`), `DistanceMatrix`, and `SymmetricMatrix` hold a `std::shared_ptr` buffer. The shallow copy in `_set_element` (`self(index) = val`) and in `assign_from` (`T(rhs_view(idx))`) made tensor cells **share the source's buffer**:

```python
t = sb.zeros((2,), dtype=sb.distmat64)
m = DistanceMatrix(3); m[0, 1] = 2.0
t[0] = m; m[0, 2] = 8.0     # was: t[0][0, 2] == 8.0  (cell aliased the source)

t[0] = shared; t[1] = shared
t[0][0, 1] = 99.0           # was: t[1][0, 1] == 99.0 (siblings aliased)
```

## Approach

I first tried giving the matrix types value-semantic (deep) copy constructors, but that **broke `pdist`/`l2_kernel`** — their result-writer pipeline relies on shallow buffer sharing. So instead:

- Add a deep `copy()` method to `DistanceMatrix`/`SymmetricMatrix` (default copy stays shallow, as the internals expect).
- Add `sb::detail::store_copy(v)` (`tensor.hpp`): deep-copies element types that expose `copy()` (Tensor/PointCloud and the matrices) via `if constexpr (requires { v.copy(); })`, and returns value types (`float`, `Pcf`) unchanged.
- `_set_element` and `assign_from` now store `store_copy(element)`, so cells are independent of the source and of each other — matching NumPy object-array assignment — while pdist/l2_kernel are untouched.

> Note: this edits `assign_from`, which **PR #125 (issue #6)** also edits. The two changes compose (this wraps the stored element in `store_copy`; #125 copies the RHS view when it overlaps) and only conflict textually — trivial to resolve by keeping both.

## Tests

`test/python/test_bugscan_element_assign.py`:
- `test_distmat_cell_independent_of_source_after_assign`
- `test_matrix_cells_from_same_source_are_independent` (distmat + symmat)
- `test_pcloud_cell_independent_of_source_and_sibling`
- `test_matrix_slice_assignment_is_independent` (distmat + symmat)
- `test_mutating_one_cell_leaves_others_untouched`

Full suites green: **404** C++ and **1644** Python tests pass (31 skipped) — including `test_pdist.py`, `test_symmetric_matrix_tensor.py`, `test_point_cloud_tensors.py`.

Fixes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLUKg7KqfRzMq9A5VLr6pj)_