### PR TITLE
Normalize negative shape axes

### DIFF
--- a/stablebear/_tensor_base.py
+++ b/stablebear/_tensor_base.py
@@ -147,6 +147,16 @@ def _resolve_negative_indices(index_tensor, axis_size):
     return IntTensor(arr)
 
 
+def _resolve_axis(axis: int, ndim: int) -> int:
+    axis = operator.index(axis)
+    resolved = axis + ndim if axis < 0 else axis
+    if not 0 <= resolved < ndim:
+        raise IndexError(
+            f"axis {axis} is out of range for tensor with {ndim} dimension(s)"
+        )
+    return resolved
+
+
 class Tensor(ABC):
     _data: CppTensor
 
@@ -709,7 +719,10 @@ class Tensor(ABC):
         return self._to_py_tensor(self._data.reshape(list(shape)))
 
     def transpose(self, axes=None):
-        return self._to_py_tensor(self._data.transpose(list(axes) if axes else []))
+        if axes is None:
+            return self._to_py_tensor(self._data.transpose([]))
+        resolved_axes = [_resolve_axis(axis, self.ndim) for axis in axes]
+        return self._to_py_tensor(self._data.transpose(resolved_axes))
 
     @property
     def T(self):
@@ -729,7 +742,7 @@ class Tensor(ABC):
     def squeeze(self, axis=None):
         if axis is None:
             return self._to_py_tensor(self._data.squeeze())
-        return self._to_py_tensor(self._data.squeeze(axis))
+        return self._to_py_tensor(self._data.squeeze(_resolve_axis(axis, self.ndim)))
 
     def expand_dims(self, axis):
         return self._to_py_tensor(self._data.expand_dims(axis))

--- a/test/python/test_tensor_reshape.py
+++ b/test/python/test_tensor_reshape.py
@@ -150,6 +150,20 @@ class TestTranspose:
     def test_3d_transpose_axes(self, TensorType, np_dtype):
         _assert_transpose(np.arange(24, dtype=np_dtype).reshape(2, 3, 4), (2, 0, 1), TensorType)
 
+    def test_3d_transpose_negative_axes(self, TensorType, np_dtype):
+        _assert_transpose(
+            np.arange(24, dtype=np_dtype).reshape(2, 3, 4),
+            (-1, -2, -3),
+            TensorType,
+        )
+
+    def test_3d_transpose_mixed_negative_axes(self, TensorType, np_dtype):
+        _assert_transpose(
+            np.arange(24, dtype=np_dtype).reshape(2, 3, 4),
+            (2, 1, -3),
+            TensorType,
+        )
+
     def test_1d_T_is_noop(self, TensorType, np_dtype):
         np_arr = np.arange(5, dtype=np_dtype)
         t = TensorType(np_arr)
@@ -256,6 +270,10 @@ class TestSqueeze:
 
     def test_squeeze_last_axis(self, TensorType, np_dtype):
         _assert_squeeze(np.arange(6, dtype=np_dtype).reshape(1, 6, 1), 2, TensorType)
+
+    def test_squeeze_negative_axes(self, TensorType, np_dtype):
+        _assert_squeeze(np.arange(6, dtype=np_dtype).reshape(1, 6, 1), -1, TensorType)
+        _assert_squeeze(np.arange(6, dtype=np_dtype).reshape(1, 6, 1), -3, TensorType)
 
     def test_squeeze_no_size1_dims(self, TensorType, np_dtype):
         _assert_squeeze(np.arange(12, dtype=np_dtype).reshape(3, 4), None, TensorType)


### PR DESCRIPTION
﻿## Summary

This normalizes negative axes in the Python tensor wrapper before the values cross into the pybind layer.

`transpose()` now resolves each supplied axis against `self.ndim`, and `squeeze(axis)` does the same for a single axis. That keeps these shape operations consistent with NumPy and with the existing `swapaxes()` wrapper, which already handled negative axes before calling the C++ backend.

Fixes #17.
Fixes #18.

## Validation

- `BUILD_WITH_CUDA=0 SKIP_STUBGEN=1 python -m pip install .`
- `cd test && python -m pytest python/test_tensor_reshape.py`
- Manual smoke check from `test/` for `transpose((-1, -2, -3))`, `transpose((2, 1, -3))`, `squeeze(-1)`, and `squeeze(-3)`

I also ran `python -m ruff check stablebear/_tensor_base.py test/python/test_tensor_reshape.py`; it reports existing repository-wide style findings in `_tensor_base.py` such as local import ordering and the existing `Union[...]` annotation, so I left those unrelated cleanups out of this bug fix.
