### PR TITLE
fix: make a single PointCloud subscriptable (#133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.4
+
+### Bug fixes
+
+* **A single point cloud is now subscriptable** — a 0-d `PointCloudTensor` (one cloud, e.g. `sb.PointCloudTensor(arr)` from an `(n_points, dim)` array) can be indexed as its underlying array, so the natural plotting idiom `pc[:, 0]` / `pc[:, 1]` works directly instead of raising `IndexError`. Indexing tensors of rank ≥ 1 still selects clouds as before. ([#133](https://github.com/kthtda/stablebear/issues/133))
+
 ## 0.4.3
 
 ### New features

--- a/docs/indexing.rst
+++ b/docs/indexing.rst
@@ -23,6 +23,23 @@ integer raises ``IndexError``::
 A NumPy integer scalar (e.g. ``np.int64(3)``) is accepted anywhere a Python
 ``int`` is.
 
+Indexing a single point cloud
+-----------------------------
+
+A 0-d ``PointCloudTensor`` wraps exactly one point cloud (for example
+``sb.PointCloudTensor(arr)`` built from an ``(n_points, dim)`` array). Indexing
+it delegates to that cloud's ``(n_points, dim)`` array, so the natural NumPy
+idiom for plotting works directly::
+
+   pc = sb.PointCloudTensor(arr)   # arr has shape (n_points, 2)
+
+   plt.scatter(pc[:, 0], pc[:, 1])  # x and y coordinate columns
+   first_point = pc[0]              # shape (2,)
+
+Tensors of clouds (rank ≥ 1) index over the clouds instead: ``X[i]`` returns
+the ``i``-th cloud as a ``FloatTensor`` (see above), which then supports the
+same column indexing.
+
 Slicing
 -------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "stablebear"
-version = "0.4.3"
+version = "0.4.4"
 authors = [ { name="Bjorn H. Wehlin", email="bwehlin@kth.se" } ]
 description = "Massively parallel computations for piecewise constant functions"
 readme = "README.md"

--- a/stablebear/base_tensor.py
+++ b/stablebear/base_tensor.py
@@ -367,6 +367,26 @@ class PointCloudTensor(Tensor):
     def _represent_element(self, element):
         return FloatTensor(element)
 
+    def _single_cloud(self):
+        """Return the lone cloud of a 0-d tensor as a ``(n_points, dim)`` FloatTensor."""
+        return self._represent_element(self._data._get_element([]))
+
+    def __getitem__(self, index):
+        """Index the tensor of clouds, or — when this is a single cloud — the cloud itself.
+
+        A 0-d ``PointCloudTensor`` wraps exactly one point cloud. Indexing it
+        delegates to that cloud's ``(n_points, dim)`` array, so the natural
+        NumPy idiom for plotting a cloud works directly::
+
+            plt.scatter(pc[:, 0], pc[:, 1])
+
+        For tensors of rank >= 1, indexing selects clouds as usual (a full
+        integer index returns one cloud as a ``FloatTensor``).
+        """
+        if self.ndim == 0:
+            return self._single_cloud()[index]
+        return super().__getitem__(index)
+
     def _decay_value(self, val):
         float_dtype = _PCLOUD_TO_FLOAT_DTYPE[self.dtype]
         t = FloatTensor(val, dtype=float_dtype)

--- a/test/python/test_point_cloud_tensors.py
+++ b/test/python/test_point_cloud_tensors.py
@@ -41,6 +41,45 @@ def test_can_create_point_clouds():
     assert Y[1, 1].shape == (40, 15, 10)
 
 
+def test_single_cloud_is_subscriptable():
+    # A 0-d PointCloudTensor wraps a single cloud; it should be indexable as
+    # its (n_points, dim) array so the natural pc[:, 0] / pc[:, 1] plotting
+    # idiom works directly (see issue #133).
+    arr = np.random.RandomState(0).rand(6, 2)
+    pc = sb.PointCloudTensor(arr)
+    assert pc.ndim == 0
+
+    assert pc[:, 0].array_equal(arr[:, 0])
+    assert pc[:, 1].array_equal(arr[:, 1])
+    assert pc[0].array_equal(arr[0])
+    assert pc[1:3].array_equal(arr[1:3])
+
+    # Whole-cloud element access is unchanged.
+    assert pc[()].array_equal(arr)
+    assert pc[...].array_equal(arr)
+
+
+def test_tensor_of_clouds_indexing_unchanged():
+    # Rank >= 1 tensors still index over clouds, not into them.
+    arr = np.random.RandomState(1).rand(5, 2)
+    T = sb.zeros((3,), dtype=sb.pcloud64)
+    T[0] = arr
+
+    assert isinstance(T[0], sb.FloatTensor)
+    assert T[0].shape == (5, 2)
+    assert T[0][:, 1].array_equal(arr[:, 1])
+
+    sub = T[1:]
+    assert isinstance(sub, sb.PointCloudTensor)
+    assert sub.shape == (2,)
+
+    # Selecting one cloud from a higher-rank tensor, then column-indexing it.
+    grid = sb.zeros((2, 3), dtype=sb.pcloud64)
+    grid[0, 1] = arr
+    assert grid[0, 1][:, 0].array_equal(arr[:, 0])
+    assert grid[0, 1][3].array_equal(arr[3])
+
+
 def test_stored_is_same_as_numpy():
     shape = (10, 20, 30)
     pclouds = sb.zeros(shape, dtype=sb.pcloud64)


### PR DESCRIPTION
## Summary

A 0-d `PointCloudTensor` wraps exactly one cloud — e.g. `sb.PointCloudTensor(arr)` built from an `(n_points, dim)` array. Indexing it previously raised:

```
IndexError: too many indices for tensor: tensor is 0-dimensional, but 2 were indexed
```

so the natural plotting idiom did not work:

```python
plt.scatter(pc[:, 0], pc[:, 1])   # IndexError
```

`PointCloudTensor.__getitem__` now delegates to the underlying cloud's `(n_points, dim)` array when the tensor is 0-d, so `pc[:, 0]`, `pc[:, 1]`, `pc[i]` all work. Tensors of rank ≥ 1 still index over clouds as before; selecting one cloud (`pcs[0, 1]`) already returned a `FloatTensor` that supports column indexing.

Closes #133.

## Changes

- `stablebear/base_tensor.py` — `PointCloudTensor.__getitem__` / `_single_cloud` delegate 0-d indexing to the underlying cloud.
- `test/python/test_point_cloud_tensors.py` — tests for single-cloud subscripting, unchanged rank ≥ 1 behavior, and chained `pcs[0,1][:,0]` selection.
- `docs/indexing.rst` — new "Indexing a single point cloud" subsection.
- `CHANGELOG.md` / `pyproject.toml` — start `0.4.4`.

## Testing

- `python -m pytest python/test_point_cloud_tensors.py` — pass
- Full Python suite (`python -m pytest python`) — 1684 passed, 30 skipped