### PR TITLE
Pcf rejects duplicate breakpoint times and empty input (#56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Breaking changes
 
 * **`Pcf` no longer sorts breakpoints; unsorted, negative, and offset times are rejected** — `Pcf` construction used to silently sort the supplied `(time, value)` rows and checked the `t=0` requirement on the unsorted input row 0, so out-of-order breakpoints were accepted and a negative time on a later row could be reordered to the front into a malformed PCF that then evaluated at negative times. Breakpoints must now be supplied in non-decreasing time order (out-of-order input raises `ValueError` instead of being silently sorted), and the first time must be 0 — so any input whose first time is not 0, in particular any negative time, raises `ValueError`. `Pcf` evaluation also rejects `t < 0` directly (it previously compared against the first breakpoint rather than 0). ([#11](https://github.com/kthtda/stablebear/issues/11))
+* **`Pcf` requires strictly increasing breakpoint times and rejects empty input** — completing the `Pcf` validation above: a duplicate breakpoint time previously slipped past the `non-decreasing` check despite the documented strictly-increasing contract, and is now rejected with `ValueError`. Constructing a `Pcf` from an empty `(0, 2)` array (which used to silently fabricate a single `(0, 0)` breakpoint) now raises `ValueError`; use `Pcf()` for the all-zero constant PCF. ([#56](https://github.com/kthtda/stablebear/issues/56))
 
 ### Bug fixes
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -27,7 +27,7 @@ In stablebear, a PCF is represented as an :math:`n \times 2` array of ``(time, v
 
 The value at each breakpoint is the value on the interval starting at that time and continuing until the next breakpoint (or until the end of the function's domain).
 
-The breakpoints must be listed in non-decreasing order of time, and the first time must be ``0`` (PCFs are defined on :math:`[0, \infty)`). Breakpoints given out of order, a first time other than ``0``, or any negative time raise a ``ValueError``.
+The breakpoint times must be strictly increasing (:math:`t_0 < t_1 < \cdots`), and the first time must be ``0`` (PCFs are defined on :math:`[0, \infty)`). Out-of-order or duplicate times, a first time other than ``0``, any negative time, or an empty array raise a ``ValueError``.
 
 Why PCFs?
 ---------

--- a/src/python/pypcf_support.hpp
+++ b/src/python/pypcf_support.hpp
@@ -41,8 +41,11 @@ namespace sb
       py::buffer_info buf = arr.request();
       if (buf.size == 0)
       {
-        points.emplace_back(static_cast<Tt>(0), static_cast<Tv>(0));
-        return sb::Pcf<Tt, Tv>(std::move(points));
+        // A PCF must have at least one breakpoint at t=0; an empty input array
+        // cannot represent one. (Use Pcf() for the all-zero constant PCF.)
+        throw std::invalid_argument(
+          "Cannot construct a Pcf from an empty array; a PCF must have at "
+          "least one breakpoint at t=0.");
       }
 
       if (buf.ndim != 2)
@@ -77,6 +80,18 @@ namespace sb
       {
         throw std::invalid_argument(
           "Breakpoints must be given in non-decreasing time order.");
+      }
+
+      // Times must be strictly increasing (t_0 < t_1 < ...): a duplicate time
+      // is ambiguous (two values at the same breakpoint) and is rejected
+      // rather than silently kept.
+      if (std::adjacent_find(points.begin(), points.end(),
+            [](const point_type& a, const point_type& b){ return a.t == b.t; })
+          != points.end())
+      {
+        throw std::invalid_argument(
+          "Breakpoints must have strictly increasing times (a duplicate time "
+          "was supplied).");
       }
 
       // PCFs are defined on [0, inf), so the first (smallest) breakpoint time

--- a/stablebear/functional/pcf.py
+++ b/stablebear/functional/pcf.py
@@ -15,10 +15,12 @@ class Pcf:
     takes the value :math:`v_i` on the interval :math:`[t_i, t_{i+1})` for
     :math:`0 \leq i < n-1`, and :math:`v_{n-1}` on :math:`[t_{n-1}, \infty)`.
 
-    The breakpoints must be given in non-decreasing time order; a ``ValueError``
-    is raised otherwise. The first time must be :math:`t_0 = 0` (PCFs are
-    defined on :math:`[0, \infty)`): a ``ValueError`` is raised if the first
-    time is not zero — in particular if any time is negative.
+    The breakpoint times must be strictly increasing
+    (:math:`t_0 < t_1 < \cdots`); a ``ValueError`` is raised for out-of-order or
+    duplicate times. The first time must be :math:`t_0 = 0` (PCFs are defined on
+    :math:`[0, \infty)`): a ``ValueError`` is raised if the first time is not
+    zero — in particular if any time is negative. An empty input array is also
+    rejected (a PCF must have at least one breakpoint).
 
     Parameters
     ----------

--- a/test/python/test_bugscan_pcf.py
+++ b/test/python/test_bugscan_pcf.py
@@ -54,3 +54,30 @@ def test_eval_negative_time_array_raises():
     f = Pcf(np.array([[0.0, 1.0], [2.0, 2.0]], dtype=np.float64))
     with pytest.raises(Exception, match="time 0"):
         f(np.array([-0.5, 0.5]))
+
+
+# ---------------------------------------------------------------------------
+# Bug #56: Pcf construction silently accepted duplicate breakpoint times
+# (contradicting the strictly-increasing contract) and turned an empty (0, 2)
+# input array into a fabricated 1-point PCF. Both are now rejected.
+# ---------------------------------------------------------------------------
+
+
+def test_pcf_rejects_duplicate_times():
+    with pytest.raises(ValueError, match="strictly increasing"):
+        Pcf(np.array([[0.0, 5.0], [1.0, 6.0], [1.0, 7.0]]))
+
+
+def test_pcf_rejects_duplicate_first_times():
+    with pytest.raises(ValueError, match="strictly increasing"):
+        Pcf(np.array([[0.0, 5.0], [0.0, 6.0]]))
+
+
+def test_pcf_rejects_empty_array():
+    with pytest.raises(ValueError, match="empty"):
+        Pcf(np.zeros((0, 2)))
+
+
+def test_pcf_strictly_increasing_still_constructs():
+    f = Pcf(np.array([[0.0, 1.0], [1.0, 2.0], [3.0, 0.0]]))
+    assert f.size == 3

--- a/test/python/test_from_serial_content.py
+++ b/test/python/test_from_serial_content.py
@@ -73,12 +73,15 @@ def test_fsc_multidim():
 
     assert X.shape == (3, 2)
 
-    assert X[0, 0] == sb.Pcf(content[enumeration[0, 0, 0] : enumeration[0, 0, 1]])
-    assert X[0, 1] == sb.Pcf(content[enumeration[0, 1, 0] : enumeration[0, 1, 1]])
-    assert X[1, 0] == sb.Pcf(content[enumeration[1, 0, 0] : enumeration[1, 0, 1]])
-    assert X[1, 1] == sb.Pcf(content[enumeration[1, 1, 0] : enumeration[1, 1, 1]])
-    assert X[2, 0] == sb.Pcf(content[enumeration[2, 0, 0] : enumeration[2, 0, 1]])
-    assert X[2, 1] == sb.Pcf(content[enumeration[2, 1, 0] : enumeration[2, 1, 1]])
+    # from_serial_content is a loose deserialization constructor and may produce
+    # PCFs with duplicate breakpoint times (e.g. the [5:9] / [13:15] slices here
+    # are all t=0), which the strict public Pcf(array) constructor rejects. Test
+    # the slicing by comparing the produced PCF's breakpoints to the source
+    # slice directly, rather than rebuilding the expected value via Pcf(...).
+    for i in range(3):
+        for j in range(2):
+            start, stop = enumeration[i, j, 0], enumeration[i, j, 1]
+            np.testing.assert_array_equal(np.asarray(X[i, j]), content[start:stop])
 
 
 def test_fsc_stop_le_start_throws():

--- a/test/python/test_numpy.py
+++ b/test/python/test_numpy.py
@@ -5,8 +5,10 @@ import stablebear._sb_cpp as cpp
 
 
 def test_np_to_pcf_has_correct_type():
-    X32 = np.zeros((2, 2), dtype=np.float32)
-    X64 = np.zeros((2, 2), dtype=np.float64)
+    # Strictly-increasing breakpoint times (t=0, 1); the test only checks dtype
+    # inference, but the times must be valid for the strict Pcf constructor.
+    X32 = np.array([[0.0, 0.0], [1.0, 0.0]], dtype=np.float32)
+    X64 = np.array([[0.0, 0.0], [1.0, 0.0]], dtype=np.float64)
 
     f32 = sb.Pcf(X32)
     assert isinstance(f32._data, cpp.Pcf_f32_f32)


### PR DESCRIPTION
## Summary

Completing the stricter `Pcf` validation from #11/#124:

- **Duplicate times** — the order check used `std::is_sorted` with a `<` comparator, which treats equal consecutive times as "sorted", so a `Pcf` with duplicate breakpoint times (e.g. two rows at `t=0`) was silently accepted, contradicting the documented strictly-increasing contract (`t_0 < t_1 < ...`).
- **Empty input** — `Pcf(np.zeros((0, 2)))` silently fabricated a single `(0, 0)` breakpoint instead of reporting that a PCF needs at least one breakpoint.

## Fix (`src/python/pypcf_support.hpp::construct_pcf`)

- After the non-decreasing-order check, reject any duplicate time via `std::adjacent_find` (clear `ValueError`: "strictly increasing times").
- Reject an empty input array with a `ValueError` (use `Pcf()` for the all-zero constant PCF — its default constructor is unchanged).

`from_serial_content` is a separate loose deserialization path (it does not go through `construct_pcf`) and is unaffected — it can still produce duplicate-time PCFs from serialized data.

Docstring (`stablebear/functional/pcf.py`) and `docs/concepts.rst` updated to say "strictly increasing" and note the empty-array rejection.

## Tests

- `test/python/test_bugscan_pcf.py`: duplicate times (interior and leading) and empty `(0, 2)` input raise `ValueError`; a strictly-increasing PCF still constructs.
- Updated two pre-existing tests that fed degenerate data through the now-strict `Pcf(array)` constructor: `test_from_serial_content.py::test_fsc_multidim` (slices with all-`t=0` rows) now compares the produced PCF's breakpoints to the source slice directly; `test_numpy.py::test_np_to_pcf_has_correct_type` (which used `np.zeros((2,2))` purely for dtype inference) now uses valid strictly-increasing times.

Full Python suite (1803) and C++ suite (442) pass.

Closes #56

https://claude.ai/code/session_01QBu4JpzR3hXvBcEXTd47J7