### PR TITLE
fix: add allclose method with broadcasting support (closes #52)

### DIFF
--- a/stablebear/base_tensor.py
+++ b/stablebear/base_tensor.py
@@ -93,6 +93,17 @@ class NumericTensor(Tensor, ArithmeticTensorMixin):
             return np.array_equal(np.asarray(self), other)
         return super().array_equal(other)
 
+    def allclose(self, other, rtol=1e-05, atol=1e-08, equal_nan=False) -> bool:
+        """Returns True if two arrays are element-wise equal within a tolerance (following numpy's allclose with broadcasting)."""
+        import numpy as np
+        a = np.asarray(self)
+        b = np.asarray(other) if isinstance(other, Tensor) else other
+        try:
+            return np.allclose(a, b, rtol=rtol, atol=atol, equal_nan=equal_nan)
+        except ValueError:
+            # numpy raises on incompatible shapes, propagate
+            raise
+
     def __floordiv__(self, rhs):
         rhs_arr = np.asarray(rhs) if isinstance(rhs, NumericTensor) else rhs
         return self._to_py_tensor(np.asarray(self) // rhs_arr)


### PR DESCRIPTION
## What
`allclose` (likely defined in C++ or base class) returned `False` on any shape mismatch, ignoring broadcasting semantics the rest of the library supports. This masked user bugs by returning a silent `False` instead of broadcasting-compatible comparison or raising on truly incompatible shapes.

## Fix
Override `allclose` in `NumericTensor` to convert both tensors to NumPy arrays and use `np.allclose`, which correctly broadcasts compatible shapes and raises `ValueError` on incompatible ones. This matches the library's own broadcasting behavior in arithmetic and equality.

Closes #52