### PR TITLE
Fix mechanical issues from repo review: broken TestPyPI publish, Codecov token, GPU detection dead code, CMake/doc fixes

### DIFF
--- a/.github/workflows/analysis-github.yaml
+++ b/.github/workflows/analysis-github.yaml
@@ -7,5 +7,6 @@ permissions:
 jobs:
   analysis:
     uses: ./.github/workflows/analysis.yaml
+    secrets: inherit
     with:
       use_github_runners: true

--- a/.github/workflows/analysis.yaml
+++ b/.github/workflows/analysis.yaml
@@ -11,6 +11,9 @@ on:
       use_github_runners:
         type: boolean
         default: false
+    secrets:
+      CODECOV_TOKEN:
+        required: false
 permissions:
   contents: write
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,8 @@ name: CI
 #   - analysis.yaml   with use_github_runners: true  (skips the cuda_test job)
 
 on:
+  push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 
@@ -65,5 +67,6 @@ jobs:
     permissions:
       contents: write
     uses: ./.github/workflows/analysis.yaml
+    secrets: inherit
     with:
       use_github_runners: true

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -65,6 +65,7 @@ jobs:
     permissions:
       contents: write
     uses: ./.github/workflows/analysis.yaml
+    secrets: inherit
     needs: check_version
 
   publish:

--- a/.github/workflows/publish-pypitest.yaml
+++ b/.github/workflows/publish-pypitest.yaml
@@ -25,6 +25,7 @@ jobs:
     permissions:
       contents: write
     uses: ./.github/workflows/analysis.yaml
+    secrets: inherit
     needs: check_version
 
   build:
@@ -42,7 +43,7 @@ jobs:
       - name: Download wheels
         uses: actions/download-artifact@v8
         with:
-          name: cpu-wheels
+          name: wheels
           path: dist/
 
       - name: Compare wheels
@@ -66,7 +67,7 @@ jobs:
       - name: Download wheels
         uses: actions/download-artifact@v8
         with:
-          name: cpu-wheels
+          name: wheels
           path: dist/
 
       - name: Publish to TestPyPI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ This works when `SKBUILD` is off (plain CMake). Builds `_sb_cpu` (always) and `_
 
 ## Testing
 
-**Important**: Always `cd test` before running pytest. Running from the repo root causes the local `stablebear/` directory to shadow the installed package. You must also build and install first.
+**Important**: Tests require `pytest` and `scipy` (`pip install pytest scipy`). Always `cd test` before running pytest. Running from the repo root causes the local `stablebear/` directory to shadow the installed package. You must also build and install first.
 
 ### Python tests
 ```bash
@@ -60,31 +60,34 @@ cd test && ../cmake-build-debug/sb_test  # run from test/ directory
 - **`stablebear/_sb_cpp.py`** is the runtime backend selector. It detects GPU availability, preloads libcudart if needed, and imports `_sb_cuda{12,13}` or falls back to `_sb_cpu`. All other Python code imports through this module.
 - **`src/python/`** contains pybind11 bindings. Each `py_*.cpp` wraps a corresponding C++ subsystem.
 - **`src/gpu_detect/`** is a separate pybind11 module (`_gpu_detect`) with no CUDA dependency — used to detect GPUs without requiring the CUDA toolkit.
-- NumPy array ↔ C++ tensor conversion happens in `py_np_tensor_convert.{h,cpp}` (zero-copy where possible).
+- NumPy array ↔ C++ tensor conversion happens in `py_np_tensor_convert.{hpp,cpp}` (zero-copy where possible).
 
 ### C++ core (`include/sbear/`)
-- **`pcf.h`** — `Pcf<TimeT, ValueT>` template, the fundamental piecewise constant function type
-- **`tensor.h` / `tensor.tpp`** — N-dimensional tensor template (stores PCFs, floats, point clouds, or barcodes)
-- **`algorithms/`** — core algorithms: `matrix_integrate.h` (distance matrices), `reduce.h`, `iterate_rectangles.h`, `subdivide.h`, `apply_functional.h`
+- **`functional/pcf.hpp`** — `Pcf<TimeT, ValueT>` template, the fundamental piecewise constant function type
+- **`tensor.hpp` / `tensor.tpp`** — N-dimensional tensor template (stores PCFs, floats, point clouds, or barcodes)
+- **`algorithms/`** — core algorithms: `subdivide.hpp`, `tensor_eval.hpp`, and under `algorithms/functional/`: `matrix_integrate.hpp` (distance matrices), `reduce.hpp`, `iterate_rectangles.hpp`, `apply_functional.hpp`, `matrix_reduce.hpp`, `lp_distance.hpp`
 - **`persistence/`** — TDA: ripser algorithm, barcodes, stable rank
 - **`cuda/`** — CUDA kernels for matrix operations
-- **`executor.h`** — taskflow-based parallel task dispatch (CPU)
+- **`executor.hpp`** — taskflow-based parallel task dispatch (CPU)
 
 ### Type system
 Each tensor class supports multiple precisions via a `dtype` parameter: `PcfTensor` (dtype=pcf32/pcf64), `IntPcfTensor` (dtype=pcf32i/pcf64i), `FloatTensor` (dtype=float32/float64), `PointCloudTensor` (dtype=pcloud32/pcloud64), `BarcodeTensor` (dtype=barcode32/barcode64), `DistanceMatrixTensor` (dtype=distmat32/distmat64), `SymmetricMatrixTensor` (dtype=symmat32/symmat64). Dtype sentinels live in `stablebear/typing.py`. The C++ layer still has separate types per precision (e.g. `cpp.Float32Tensor`, `cpp.Float64Tensor`); the Python classes dispatch internally.
 
 ### Python module layers
 1. **Low**: `_sb_cpp` (backend dispatch) → `_sb_cpu` / `_sb_cudaXX` (pybind11)
-2. **Mid**: `pcf.py`, `tensor.py`, `_tensor_base.py` (Python wrappers)
+2. **Mid**: `functional/pcf.py`, `base_tensor.py`, `_tensor_base.py` (Python wrappers)
 3. **High**: `distance.py` (`pdist`), `reductions.py` (`mean`, `max_time`), `norms.py`, `persistence/`
 
 ### GPU/CPU runtime control (`stablebear/system.py`)
 `force_cpu()`, `limit_cpus()`, `limit_gpus()`, `set_cuda_threshold()`, `set_device_verbose()` — all configure the backend at runtime.
 
-## Third-party submodules (`3rd/`)
+## Third-party code (`3rd/`)
+Git submodules (run `git submodule update --init` after a non-recursive clone, or the build fails at `add_subdirectory(3rd/pybind11)`):
 - **pybind11** — Python/C++ bindings
 - **taskflow** — CPU task parallelism (header-only, included directly)
 - **googletest** — C++ unit tests
+
+Vendored directly (not submodules): **ripser** (persistent homology), **xoroshiro** / **splitmix64** (RNG), **cuda**, **gcc-runtime**, **msvc-runtime** (runtime support headers).
 
 ## Documentation (`docs/`)
 - Sphinx docs live in `docs/`, built with `make html` from that directory.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,6 +262,7 @@ else ()
 endif ()
 
 set(PROJ_NAME stablebear)
+set(PROJECT_TITLE "${PROJ_NAME}")
 
 # Read version info out of pyproject.toml
 file(READ "${CMAKE_CURRENT_SOURCE_DIR}/pyproject.toml" TOML_CONTENT)
@@ -284,7 +285,7 @@ if (PROJECT_BODY MATCHES [[version[ \t]*=[ \t]*"([^"]+)"]])
 
   set(PROJ_VERSION "${PROJ_VERSION_NUMERIC}")
 else ()
-  message(FATAL "Could not detect version number from pyproject.toml!")
+  message(FATAL_ERROR "Could not detect version number from pyproject.toml!")
 endif ()
 
 project(${PROJ_NAME} VERSION ${PROJ_VERSION_NUMERIC} LANGUAGES CXX ${LANG_CUDA})
@@ -757,7 +758,7 @@ foreach(MOD_NAME IN LISTS CPP_MODULE_NAMES)
   target_include_directories(${MOD_NAME} PRIVATE ${SB_PRIVATE_INCLUDES})
   target_include_directories(${MOD_NAME} PUBLIC ${SB_PUBLIC_INCLUDES})
   target_link_libraries(${MOD_NAME} PRIVATE pybind11::headers)
-  target_compile_definitions(${MOD_NAME} PRIVATE VERSION_INFO=${PROJECT_VERSION_FULL})
+  target_compile_definitions(${MOD_NAME} PRIVATE VERSION_INFO=${PROJ_VERSION_FULL})
   sb_apply_cpu_arch_flags(${MOD_NAME})
 endforeach()
 
@@ -991,7 +992,7 @@ foreach(MOD_NAME IN LISTS CPP_MODULE_NAMES)
 endforeach()
 
 if (NOT MSVC)
-  set(CMAKE_CXX_FLAGS "-Wall -Wextra -Werror=return-type")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror=return-type")
 endif ()
 
 if (POLICY CMP0177)
@@ -1213,7 +1214,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND BUILD_TESTER)
   target_link_libraries(sb_test PRIVATE valgrind_flags)
 endif()
 
-message(STATUS "!!! Stub file:          ${STUB_FILE}")
 message(STATUS "!!! Install target:     ${INSTALL_TARGET}")
 
 message(STATUS "!!! C compiler:         ${CMAKE_C_COMPILER}")

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -54,7 +54,7 @@ An individual PCF is represented by :py:class:`~stablebear.Pcf`. You create one 
                      [5.0, 0.0]], dtype=np.float32)
    f = sb.Pcf(data)
 
-   # From a list (defaults to float32)
+   # From a list (defaults to float64)
    g = sb.Pcf([[0, 1], [2, 3], [5, 0]])
 
 You can convert a ``Pcf`` back to a NumPy array with :py:meth:`~stablebear.Pcf.to_numpy`::

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,7 +75,6 @@ if gen_cpp_docs:
     }
 
 
-templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "**/.virtual_documents"]
 
 

--- a/docs/distances.rst
+++ b/docs/distances.rst
@@ -207,7 +207,7 @@ Tensors of symmetric matrices use the ``symmat32`` or ``symmat64`` dtypes::
 Norms
 =====
 
-:py:func:`~stablebear.lp_norm` computes the :math:`L_p` norm of every PCF in a tensor, returning a NumPy array of the same shape.
+:py:func:`~stablebear.lp_norm` computes the :math:`L_p` norm of every PCF in a tensor, returning a :py:class:`~stablebear.FloatTensor` of the same shape.
 
 ::
 

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -36,7 +36,7 @@ To build a specific branch or tag from a Git checkout::
     cd stablebear
 
     # optional: select a specific tagged version to build
-    git checkout tags/v0.4.1
+    git checkout tags/v0.4.4
 
     pip install .
 

--- a/docs/persistence.rst
+++ b/docs/persistence.rst
@@ -14,7 +14,7 @@ The output is a **persistence barcode**: a collection of intervals :math:`[b_i, 
 
 stablebear provides three functional summaries of persistence barcodes, all of which are piecewise constant functions:
 
-- The (1d) **stable rank** counts, for each threshold :math:`t`, how many bars have length at least :math:`t` :footcite:`Chacholski2020,Gafvert2017,Scolamiero2017`.
+- The (1d) **stable rank** counts, for each threshold :math:`t`, how many bars have length strictly greater than :math:`t` :footcite:`Chacholski2020,Gafvert2017,Scolamiero2017`.
 - The **Betti curve** counts, for each filtration value :math:`t`, how many bars are alive at :math:`t` (see, e.g., :footcite:`Umeda2017,Chazal2021`).
 - The **accumulated persistence function** (APF) sums, for each mean age :math:`m`, the lifetimes of all bars whose midpoint is at most :math:`m` :footcite:`Biscio2019`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 requires = [
     'scikit-build-core>=0.12',
     'numpy>=2.0',
-    'pybind11_stubgen',
 ]
 build-backend = "scikit_build_core.build"
 

--- a/src/gpu_detect/gpu_detect.cpp
+++ b/src/gpu_detect/gpu_detect.cpp
@@ -41,6 +41,15 @@ std::vector<GpuInfo> detect_gpus()
   const struct dirent* entry;
   while ((entry = readdir(drm)) != nullptr)
   {
+    // Each GPU exposes several drm nodes (cardN, renderDN, connectors);
+    // count only primary card nodes to avoid double-counting devices.
+    const std::string node_name = entry->d_name;
+    if (node_name.rfind("card", 0) != 0 || node_name.size() == 4 ||
+        node_name.find_first_not_of("0123456789", 4) != std::string::npos)
+    {
+      continue;
+    }
+
     std::string base = "/sys/class/drm/";
     base += entry->d_name;
     std::string device_path = base + "/device/";

--- a/stablebear/__init__.py
+++ b/stablebear/__init__.py
@@ -44,6 +44,12 @@ from .typing import (
     uint64,
 )
 
+try:
+    from importlib.metadata import version as _pkg_version
+    __version__ = _pkg_version("stablebear")
+except Exception:  # source tree without installed metadata
+    __version__ = "unknown"
+
 import types as _types
 __all__ = sorted(
     name for name in set(dir()) - __before - {"__before"}

--- a/stablebear/gpu.py
+++ b/stablebear/gpu.py
@@ -5,7 +5,7 @@ falling back to a pure-Python implementation using subprocess.
 """
 
 try:
-    from _gpu_detect import detect_nvidia_gpus, has_nvidia_gpu, nvidia_gpu_count
+    from ._gpu_detect import detect_nvidia_gpus, has_nvidia_gpu, nvidia_gpu_count
 except ImportError:
     import os
     import platform
@@ -42,6 +42,10 @@ except ImportError:
         drm_path = "/sys/class/drm"
         if os.path.isdir(drm_path):
             for entry in os.listdir(drm_path):
+                # Each GPU exposes several drm nodes (cardN, renderDN,
+                # connectors); count only primary card nodes.
+                if not re.fullmatch(r"card\d+", entry):
+                    continue
                 vendor_file = os.path.join(drm_path, entry, "device", "vendor")
                 if os.path.isfile(vendor_file):
                     try:


### PR DESCRIPTION
Batch of small, mechanical fixes for issues filed during the recent repo review. Each change is scoped to exactly what its issue describes; behavioral changes that deserve tests (#182–#196 etc.) are intentionally left out.

## CI / workflows
- **Fixes #162** — `publish-pypitest.yaml` now downloads the `wheels` artifact that `wheels.yaml` actually produces (was: nonexistent `cpu-wheels`, which made every TestPyPI publish run fail at the download step).
- **Fixes #163** — `secrets: inherit` added at every `analysis.yaml` call site (ci, publish-pypi, publish-pypitest, analysis-github), and `CODECOV_TOKEN` declared in the `workflow_call` block, so Codecov uploads are authenticated on PR/publish pipelines instead of silently falling back to tokenless upload.
- **Fixes #165** — `ci.yaml` now also triggers on `push` to `main`, so merged code is built/tested and the gh-pages coverage report reflects mainline. The existing concurrency group handles superseded runs.

## Build system
- **Fixes #168** — `CMAKE_CXX_FLAGS` is appended to instead of overwritten, so user/packager-supplied `CXXFLAGS` (hardening flags, arch flags) are no longer discarded.
- **Fixes #170** — `message(FATAL)` → `message(FATAL_ERROR)` (version-detection failure now aborts configure properly); `VERSION_INFO` uses the actually-set `PROJ_VERSION_FULL`; `PROJECT_TITLE` is defined so `sb::PROJECT_TITLE` is no longer an empty string; removed the status print of never-set `STUB_FILE`.
- **Fixes #172** — dropped `pybind11_stubgen` from `[build-system].requires`; SKBUILD builds force `SKIP_STUBGEN ON` unconditionally, so it was installed into every isolated build env and never used.

## GPU detection
- **Addresses #173** (items 1 and 2) — `gpu.py` now imports `._gpu_detect` relatively, matching where CMake installs the extension; previously the top-level `from _gpu_detect import ...` always raised `ImportError`, so the compiled detector was dead code and the subprocess fallback (lspci/PowerShell) always ran. Also filters `/sys/class/drm` entries to primary `cardN` nodes in **both** the C++ detector and the Python sysfs fallback, fixing the 2× GPU double-count. The WSL2 detection gap (item 3 of #173) is left open.

## Python
- **Fixes #198** — `stablebear.__version__` exposed via `importlib.metadata` (with a fallback for uninstalled source trees). Deliberately underscore-prefixed-safe: it's excluded from `__all__` by the existing filter.

## Docs
- **Fixes #175** — `concepts.rst`: list-constructed `Pcf` defaults to float64, not float32 (matches `functional/pcf.py`).
- **Fixes #178** — `lp_norm` return type corrected to `FloatTensor`; stable-rank definition at the top of `persistence.rst` aligned to "strictly greater than t" (verified against `stable_rank.hpp`: the right-continuous PCF drops the count *at* t = lifetime, so line 147 and the docstring were correct); removed `templates_path` pointing at a nonexistent directory (was breaking `-W` builds); stale `v0.4.1` checkout example bumped to `v0.4.4`.
- **Fixes #199** — CLAUDE.md: corrected stale module paths (`tensor.py` → `base_tensor.py`, `pcf.py` → `functional/pcf.py`), header names (`*.h` → `*.hpp`, current `algorithms/functional/` layout), documented the vendored (non-submodule) contents of `3rd/`, the submodule-init requirement, and the pytest/scipy test dependencies (partial overlap with #171 — the pyproject `test` extra from that issue is not included here).

## Verification
YAML files parse cleanly, `pyproject.toml` parses as TOML, and the touched Python modules compile. The C++/CMake changes are compile-level trivial but were **not** built in this sandbox (network policy blocks submodule clones) — CI on this PR is the build check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqQuCR8SgDqhKzYZECHPBF

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqQuCR8SgDqhKzYZECHPBF)_