### PR TITLE
Fix critical and high-impact bugs from the bug scan (14 issues)

### DIFF
--- a/.github/workflows/analysis.yaml
+++ b/.github/workflows/analysis.yaml
@@ -11,6 +11,9 @@ on:
       use_github_runners:
         type: boolean
         default: false
+    secrets:
+      CODECOV_TOKEN:
+        required: false
 permissions:
   contents: write
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,3 +67,5 @@ jobs:
     uses: ./.github/workflows/analysis.yaml
     with:
       use_github_runners: true
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -66,6 +66,8 @@ jobs:
       contents: write
     uses: ./.github/workflows/analysis.yaml
     needs: check_version
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-pypitest.yaml
+++ b/.github/workflows/publish-pypitest.yaml
@@ -26,6 +26,8 @@ jobs:
       contents: write
     uses: ./.github/workflows/analysis.yaml
     needs: check_version
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   build:
     uses: ./.github/workflows/wheels.yaml
@@ -42,7 +44,7 @@ jobs:
       - name: Download wheels
         uses: actions/download-artifact@v8
         with:
-          name: cpu-wheels
+          name: wheels
           path: dist/
 
       - name: Compare wheels
@@ -66,7 +68,7 @@ jobs:
       - name: Download wheels
         uses: actions/download-artifact@v8
         with:
-          name: cpu-wheels
+          name: wheels
           path: dist/
 
       - name: Publish to TestPyPI

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,7 +284,7 @@ if (PROJECT_BODY MATCHES [[version[ \t]*=[ \t]*"([^"]+)"]])
 
   set(PROJ_VERSION "${PROJ_VERSION_NUMERIC}")
 else ()
-  message(FATAL "Could not detect version number from pyproject.toml!")
+  message(FATAL_ERROR "Could not detect version number from pyproject.toml!")
 endif ()
 
 project(${PROJ_NAME} VERSION ${PROJ_VERSION_NUMERIC} LANGUAGES CXX ${LANG_CUDA})
@@ -528,6 +528,8 @@ add_subdirectory(3rd/pybind11)
 # Adapted from https://community.gigperformer.com/t/getting-cmake-variables-from-c/17711
 string(TIMESTAMP TODAY "%d/%m/%Y")
 set(PROJECT_BUILD_DATE ${TODAY})
+# Consumed by version.cpp.in (sb::PROJECT_TITLE was always empty before).
+set(PROJECT_TITLE "${PROJ_NAME}")
 configure_file(version.cpp.in ${CMAKE_CURRENT_BINARY_DIR}/version.cpp @ONLY)
 
 SET(SB_LIB_SOURCES_CUDA
@@ -757,7 +759,7 @@ foreach(MOD_NAME IN LISTS CPP_MODULE_NAMES)
   target_include_directories(${MOD_NAME} PRIVATE ${SB_PRIVATE_INCLUDES})
   target_include_directories(${MOD_NAME} PUBLIC ${SB_PUBLIC_INCLUDES})
   target_link_libraries(${MOD_NAME} PRIVATE pybind11::headers)
-  target_compile_definitions(${MOD_NAME} PRIVATE VERSION_INFO=${PROJECT_VERSION_FULL})
+  target_compile_definitions(${MOD_NAME} PRIVATE VERSION_INFO=${PROJ_VERSION_FULL})
   sb_apply_cpu_arch_flags(${MOD_NAME})
 endforeach()
 
@@ -880,6 +882,7 @@ if (BUILD_TESTER)
       test/test_offset_data_manager.cpp
       test/test_walk_random.cpp
       test/test_subdivide.cpp
+      test/test_bugscan_core.cpp
   )
 
   if (BUILD_CUDA_TESTER)
@@ -991,7 +994,9 @@ foreach(MOD_NAME IN LISTS CPP_MODULE_NAMES)
 endforeach()
 
 if (NOT MSVC)
-  set(CMAKE_CXX_FLAGS "-Wall -Wextra -Werror=return-type")
+  # Append rather than overwrite so user/packager-supplied CXXFLAGS
+  # (hardening flags, -march=..., ...) are not silently discarded.
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror=return-type")
 endif ()
 
 if (POLICY CMP0177)
@@ -1213,7 +1218,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND BUILD_TESTER)
   target_link_libraries(sb_test PRIVATE valgrind_flags)
 endif()
 
-message(STATUS "!!! Stub file:          ${STUB_FILE}")
+message(STATUS "!!! Skip stubgen:       ${SKIP_STUBGEN}")
 message(STATUS "!!! Install target:     ${INSTALL_TARGET}")
 
 message(STATUS "!!! C compiler:         ${CMAKE_C_COMPILER}")

--- a/docs/internals/cuda_engine.rst
+++ b/docs/internals/cuda_engine.rst
@@ -93,6 +93,7 @@ The square root targets roughly square blocks, which is a good default for 2D CU
    subdivide(3, 10)  ->  [0,2], [3,5], [6,8], [9,9]
    subdivide(4, 8)   ->  [0,3], [4,7]
    subdivide(5, 3)   ->  [0,2]
+   subdivide(5, 0)   ->  (no bands)
 
 Row bands and column bands are computed independently: ``rowBands = subdivide(blockSide, nRows)``, ``colBands = subdivide(blockSide, nCols)``. This means rectangular matrices are handled naturally -- the row and column band counts can differ.
 

--- a/include/sbear/algorithms/functional/matrix_reduce.hpp
+++ b/include/sbear/algorithms/functional/matrix_reduce.hpp
@@ -99,6 +99,16 @@ namespace sb
   template <typename PcfT>
   Tensor<PcfT> mean(const Tensor<PcfT>& in, size_t dim, Executor& exec = default_executor())
   {
+    // Same guard as max_element below: reducing a zero-length dimension would
+    // otherwise divide by zero and silently produce all-NaN PCFs.
+    check_reduce_dim(dim, in.shape().size());
+    if (in.shape()[dim] == 0)
+    {
+      std::ostringstream oss;
+      oss << "Cannot reduce an empty dimension: dimension " << dim << " has size 0";
+      throw std::invalid_argument(oss.str());
+    }
+
     auto ret = parallel_tensor_reduce(in, dim, [](const typename PcfT::rectangle_type& rect) {
       return rect.f_value + rect.g_value;
     }, exec);

--- a/include/sbear/algorithms/functional/reduce.hpp
+++ b/include/sbear/algorithms/functional/reduce.hpp
@@ -10,6 +10,7 @@
 #include <numeric>
 #include <algorithm>
 #include <iterator>
+#include <stdexcept>
 
 #include <taskflow/taskflow.hpp>
 #include <taskflow/algorithm/reduce.hpp>
@@ -197,6 +198,14 @@ namespace sb
 
     auto chunksz = 2;
     auto sz = std::distance(begin, end);
+    if (sz == 0)
+    {
+      // A pairwise combine has no identity element, so an empty range cannot
+      // be reduced. Reject up front with a clean, catchable exception
+      // (pybind11 maps std::invalid_argument to a Python ValueError) --
+      // mirrors the empty-dimension error in matrix_reduce.hpp.
+      throw std::invalid_argument("Cannot reduce an empty range of PCFs");
+    }
     auto blocks = subdivide(chunkszFirst , sz);
 
     auto nAll = std::accumulate(begin, end, static_cast<size_t>(0ul), [](size_t n, const pcf_type& f){ return f.points().size() + n; });

--- a/include/sbear/algorithms/subdivide.hpp
+++ b/include/sbear/algorithms/subdivide.hpp
@@ -11,6 +11,13 @@ namespace sb
   subdivide(size_t blockSize, size_t nItems)
   {
     std::vector<std::pair<size_t, size_t>> boundaries;
+    if (nItems == 0)
+    {
+      // Blocks are inclusive [first, second] ranges, so there is no way to
+      // express an empty block -- and the clamp below would wrap
+      // nItems - 1 to SIZE_MAX. No items means no blocks.
+      return boundaries;
+    }
     for (size_t i = 0ul;; i += blockSize)
     {
       if (!boundaries.empty() && boundaries.back().second == nItems - 1)

--- a/include/sbear/algorithms/tensor_eval.hpp
+++ b/include/sbear/algorithms/tensor_eval.hpp
@@ -41,6 +41,13 @@ namespace sb
     std::vector<DomainT> domain_values;
     std::vector<std::vector<size_t>> domain_indices;
     auto n = domain.size();
+    if (n == 0)
+    {
+      // out already has shape elems.shape() + domain.shape(), i.e. zero
+      // entries -- nothing to evaluate. Bail before eval_elem indexes
+      // domain_indices[0] (numpy convention: empty grid -> empty result).
+      return;
+    }
     domain_values.reserve(n);
     domain_indices.reserve(n);
     walk(domain, [&](const std::vector<size_t>& idx) {

--- a/include/sbear/cuda/cuda_block_executor.cuh
+++ b/include/sbear/cuda/cuda_block_executor.cuh
@@ -140,8 +140,10 @@ namespace sb
         exec_block(blocks[i], blockDim);
       });
 
-      m_gpuThreads.run(std::move(flow));
-      m_gpuThreads.wait_for_all();
+      // wait_for_all() discards task exceptions; get() rethrows the first
+      // CHK_CUDA failure (OOM, bad launch, ...) so it reaches the caller
+      // instead of silently leaving the remaining blocks zeroed.
+      m_gpuThreads.run(std::move(flow)).get();
 
       // Flush any pending scatter on each GPU
       for (size_t iGpu = 0; iGpu < m_nGpus; ++iGpu)

--- a/include/sbear/cuda/cuda_block_executor.cuh
+++ b/include/sbear/cuda/cuda_block_executor.cuh
@@ -114,12 +114,14 @@ namespace sb
         BlockOp& blockOp,
         const CudaBlockScheduler& scheduler,
         ResultWriter& writer,
-        std::function<void(size_t)> progressCb = [](size_t) {})
+        std::function<void(size_t)> progressCb = [](size_t) {},
+        std::function<bool()> stopRequested = [] { return false; })
       : m_gpuThreads(gpuThreads)
       , m_blockOp(blockOp)
       , m_scheduler(scheduler)
       , m_writer(writer)
       , m_progressCb(progressCb)
+      , m_stopRequested(stopRequested)
       , m_nGpus(gpuThreads.num_workers())
     {
       m_canceled.store(false);
@@ -133,7 +135,10 @@ namespace sb
 
       tf::Taskflow flow;
       flow.for_each_index<size_t, size_t, size_t>(0ul, blocks.size(), 1ul, [this, &blocks, blockDim](size_t i) {
-        if (m_canceled.load())
+        // Checked per block so a stop request (e.g. Ctrl-C via
+        // StoppableTask::request_stop) interrupts a running computation at
+        // block granularity instead of after the whole matrix.
+        if (m_canceled.load() || m_stopRequested())
         {
           return;
         }
@@ -336,6 +341,7 @@ namespace sb
     const CudaBlockScheduler& m_scheduler;
     ResultWriter& m_writer;
     std::function<void(size_t)> m_progressCb;
+    std::function<bool()> m_stopRequested;
     size_t m_nGpus;
 
     std::vector<GpuBlockStorage> m_gpuStorages;

--- a/include/sbear/cuda/cuda_offset_data_manager.cuh
+++ b/include/sbear/cuda/cuda_offset_data_manager.cuh
@@ -33,18 +33,17 @@ namespace sb
       size_t baseOffset = hostData.offsets[start];
       size_t nElements = hostData.offsets[start + count] - baseOffset;
 
-      m_localOffsets.resize(count + 1);
+      // Local scratch: one manager instance is shared by all GPU worker
+      // threads, so this must not be shared mutable state.
+      std::vector<size_t> localOffsets(count + 1);
       for (size_t i = 0; i <= count; ++i)
       {
-        m_localOffsets[i] = hostData.offsets[start + i] - baseOffset;
+        localOffsets[i] = hostData.offsets[start + i] - baseOffset;
       }
 
-      deviceOffsets.toDevice(m_localOffsets.data(), count + 1);
+      deviceOffsets.toDevice(localOffsets.data(), count + 1);
       deviceElements.toDevice(hostData.elements.data() + baseOffset, nElements);
     }
-
-  private:
-    mutable std::vector<size_t> m_localOffsets;
   };
 }
 

--- a/include/sbear/cuda/cuda_pcf_kernel.cuh
+++ b/include/sbear/cuda/cuda_pcf_kernel.cuh
@@ -31,8 +31,35 @@ namespace sb
       TriangleSkipMode skipMode;
     };
 
+    /// Index of the last breakpoint with t <= a (device analogue of the
+    /// host-side max_time_iterator_prior_to). Points are sorted by time.
+    template <typename Tt, typename Tv>
+    __device__ size_t cuda_max_time_index_prior_to(
+        const SimplePoint<Tt, Tv>* pts, size_t n, Tt a)
+    {
+      // upper_bound: first index with pts[i].t > a
+      size_t lo = 0;
+      size_t hi = n;
+      while (lo < hi)
+      {
+        size_t mid = lo + (hi - lo) / 2;
+        if (pts[mid].t <= a)
+        {
+          lo = mid + 1;
+        }
+        else
+        {
+          hi = mid;
+        }
+      }
+      return lo == 0 ? 0 : lo - 1;
+    }
+
     /// Walk two PCFs simultaneously through their breakpoints,
     /// calling cb(left, right, fValue, gValue) for each rectangle.
+    /// Mirrors the host-side iterate_rectangles (iterate_rectangles.hpp);
+    /// the two must stay in lockstep so CPU and GPU results agree for any
+    /// integration bounds [a, b].
     template<typename Tt, typename Tv, typename RectangleCallback>
     __device__ void cuda_pcf_iterate_rectangles(
         const SimplePoint<Tt, Tv>* rowPoints, size_t fOffset, size_t fsz,
@@ -45,11 +72,14 @@ namespace sb
       Tv fv;
       Tv gv;
 
-      size_t fi = 0;
-      size_t gi = 0;
-
       const SimplePoint<Tt, Tv>* fpts = rowPoints + fOffset;
       const SimplePoint<Tt, Tv>* gpts = colPoints + gOffset;
+
+      // Start at the last breakpoint <= a, like the CPU path -- starting at
+      // index 0 emits wrong values (and a negative-width leading rectangle)
+      // when there are breakpoints in (0, a].
+      size_t fi = cuda_max_time_index_prior_to(fpts, fsz, a);
+      size_t gi = cuda_max_time_index_prior_to(gpts, gsz, a);
 
       while (t < b)
       {
@@ -86,7 +116,9 @@ namespace sb
           }
         }
 
-        t = max(fpts[fi].t, gpts[gi].t);
+        // Clamp to b like the CPU path so the final rectangle does not
+        // integrate past a finite upper bound.
+        t = min(max(fpts[fi].t, gpts[gi].t), b);
         cb(tprev, t, fv, gv);
       }
     }

--- a/include/sbear/cuda/pcf_block_op.cuh
+++ b/include/sbear/cuda/pcf_block_op.cuh
@@ -181,7 +181,8 @@ namespace sb
 
         CudaBlockPipeline<value_type, block_op_t, ResultWriter> pipeline(
             m_cudaThreads, blockOp, scheduler, m_writer,
-            [this](size_t n) { add_progress(n); });
+            [this](size_t n) { add_progress(n); },
+            [this] { return stop_requested(); });
 
         if (stop_requested()) return;
         pipeline.execute(blockDim);
@@ -263,7 +264,8 @@ namespace sb
 
         CudaBlockPipeline<value_type, block_op_t, ResultWriter> pipeline(
             m_cudaThreads, blockOp, scheduler, m_writer,
-            [this](size_t n) { add_progress(n); });
+            [this](size_t n) { add_progress(n); },
+            [this] { return stop_requested(); });
 
         if (stop_requested()) return;
         pipeline.execute(blockDim);

--- a/include/sbear/functional/pcf.hpp
+++ b/include/sbear/functional/pcf.hpp
@@ -37,7 +37,13 @@ namespace sb
     explicit Pcf(std::vector<TimePoint<Tt, Tv>>&& pts)
       : m_points(std::move(pts))
     {
-
+      // evaluate and iterate_rectangles dereference the first point
+      // unconditionally; an empty PCF is UB there, so reject it here with a
+      // catchable error (e.g. a truncated file reaching io read_element).
+      if (m_points.empty())
+      {
+        throw std::invalid_argument("A PCF requires at least one point");
+      }
     }
 
     /// Converting constructor: convert from a Pcf with different precision.

--- a/include/sbear/io/pcf_io.hpp
+++ b/include/sbear/io/pcf_io.hpp
@@ -17,6 +17,18 @@ namespace sb::io::detail
   {
     using point_type = PcfT::point_type;
     auto pts = read_vector<point_type>(is);
+
+    // Validate the invariants downstream algorithms rely on, so a truncated
+    // or corrupted file yields a clean error instead of UB later. Emptiness
+    // is checked by the Pcf constructor itself.
+    for (size_t i = 1; i < pts.size(); ++i)
+    {
+      if (pts[i].t <= pts[i - 1].t)
+      {
+        throw std::runtime_error("Corrupt PCF data: breakpoint times are not strictly increasing");
+      }
+    }
+
     return PcfT(std::move(pts));
   }
 }

--- a/include/sbear/persistence/accumulated_persistence.hpp
+++ b/include/sbear/persistence/accumulated_persistence.hpp
@@ -5,6 +5,8 @@
 #include "barcode.hpp"
 #include "barcode_summary.hpp"
 
+#include <algorithm>
+
 namespace sb::ph
 {
   /**
@@ -71,7 +73,10 @@ namespace sb::ph
     std::vector<PcfPointT> points;
 
     T cumSum = T{0};
-    T lastMidpoint = T{0};
+    // Start at the earliest midpoint when it is negative (sublevel-set
+    // filtrations), mirroring barcode_to_betti_curve -- starting at 0 would
+    // emit an unsorted PCF.
+    T lastMidpoint = std::min(T{0}, entries.front().midpoint);
 
     for (auto const& entry : entries)
     {

--- a/include/sbear/persistence/betti_curve.hpp
+++ b/include/sbear/persistence/betti_curve.hpp
@@ -55,7 +55,10 @@ namespace sb::ph
     std::vector<PcfPointT> points;
 
     T count = 0;
-    T lastTime = T{0};
+    // Start at the earliest event when it is negative (sublevel-set
+    // filtrations); starting at 0 would emit a (0, 0) breakpoint followed by
+    // earlier times -- an unsorted PCF.
+    T lastTime = std::min(T{0}, events.front().time);
 
     for (auto const& event : events)
     {

--- a/include/sbear/tensor.tpp
+++ b/include/sbear/tensor.tpp
@@ -1201,10 +1201,10 @@ namespace sb
   template <typename T>
   [[nodiscard]] size_t Tensor<T>::size() const noexcept
   {
-    if (m_shape.empty())
-    {
-      return 0_uz;
-    }
+    // A rank-0 tensor holds exactly one element (numpy convention): walk()
+    // visits it and get_total_size() returns 1, so size() must agree --
+    // returning 0 made the randomized walk reserve too few RNG slots and
+    // progress/threshold logic miscount.
     return std::accumulate(m_shape.begin(), m_shape.end(), 1_uz, std::multiplies<size_t>());
   }
 

--- a/include/sbear/tensor.tpp
+++ b/include/sbear/tensor.tpp
@@ -434,6 +434,21 @@ namespace sb
         throw std::invalid_argument("Cannot broadcast in-place: output shape " +
             shape_to_string(out_shape) + " differs from LHS shape " + shape_to_string(lhs.shape()));
       auto rhs_view = rhs.broadcast_to(out_shape);
+
+      // If the RHS aliases the LHS storage (e.g. a[1:] += a[:-1], where both
+      // sides are views of the same buffer), the walk below would read
+      // elements it has already updated. Materialize an independent copy of
+      // the RHS first, matching NumPy and assign_from; data() includes the
+      // view offset, so compare the buffer base (data() - offset()).
+      if (lhs.data() - lhs.offset() == rhs.data() - rhs.offset())
+      {
+        Tensor<T> rhs_copy = rhs_view.copy();
+        sb::walk(lhs, [&](const std::vector<size_t>& idx) {
+          lhs(idx) = op(lhs(idx), rhs_copy(idx));
+        });
+        return lhs;
+      }
+
       sb::walk(lhs, [&](const std::vector<size_t>& idx) {
         lhs(idx) = op(lhs(idx), rhs_view(idx));
       });

--- a/src/gpu_detect/gpu_detect.cpp
+++ b/src/gpu_detect/gpu_detect.cpp
@@ -8,6 +8,9 @@
 #include <dirent.h>
 #include <fstream>
 #include <sstream>
+#include <cctype>
+#include <cstring>
+#include <unistd.h>
 #elif defined(_WIN32)
 #include <windows.h>
 #include <dxgi.h>
@@ -30,7 +33,22 @@ struct GpuInfo
 
 #ifdef __linux__
 
-std::vector<GpuInfo> detect_gpus()
+// Each physical GPU exposes several /sys/class/drm nodes (cardN, renderDN,
+// and per-connector nodes that resolve to the same device). Count only the
+// cardN nodes so one GPU is reported once.
+bool is_drm_card_entry(const char* name)
+{
+  if (std::strncmp(name, "card", 4) != 0 || name[4] == '\0')
+    return false;
+  for (const char* p = name + 4; *p != '\0'; ++p)
+  {
+    if (!std::isdigit(static_cast<unsigned char>(*p)))
+      return false;
+  }
+  return true;
+}
+
+std::vector<GpuInfo> detect_gpus_drm()
 {
   std::vector<GpuInfo> gpus;
 
@@ -41,6 +59,9 @@ std::vector<GpuInfo> detect_gpus()
   const struct dirent* entry;
   while ((entry = readdir(drm)) != nullptr)
   {
+    if (!is_drm_card_entry(entry->d_name))
+      continue;
+
     std::string base = "/sys/class/drm/";
     base += entry->d_name;
     std::string device_path = base + "/device/";
@@ -95,6 +116,94 @@ std::vector<GpuInfo> detect_gpus()
 
   closedir(drm);
   return gpus;
+}
+
+// The driver's procfs has one directory per GPU. Covers slim containers
+// with no lspci and no NVIDIA PCI drm entries.
+std::vector<GpuInfo> detect_gpus_proc_driver()
+{
+  std::vector<GpuInfo> gpus;
+
+  DIR* dir = opendir("/proc/driver/nvidia/gpus");
+  if (!dir)
+    return gpus;
+
+  const struct dirent* entry;
+  while ((entry = readdir(dir)) != nullptr)
+  {
+    std::string name = entry->d_name;
+    if (name == "." || name == "..")
+      continue;
+
+    GpuInfo gpu;
+    gpu.vendor_id = NVIDIA_VENDOR_ID;
+    gpu.device_id = 0;
+    gpu.name = "NVIDIA GPU [" + name + "]";
+
+    std::ifstream info_file("/proc/driver/nvidia/gpus/" + name + "/information");
+    std::string line;
+    while (std::getline(info_file, line))
+    {
+      if (line.rfind("Model:", 0) == 0)
+      {
+        auto pos = line.find_first_not_of(" \t", 6);
+        if (pos != std::string::npos)
+        {
+          gpu.name = line.substr(pos);
+        }
+        break;
+      }
+    }
+
+    gpus.push_back(std::move(gpu));
+  }
+
+  closedir(dir);
+  return gpus;
+}
+
+// WSL2 exposes the GPU through /dev/dxg with no NVIDIA PCI drm nodes.
+// /dev/dxg alone could be any vendor, so require the WSL NVIDIA driver
+// libraries as well.
+std::vector<GpuInfo> detect_gpus_wsl()
+{
+  std::vector<GpuInfo> gpus;
+
+  if (access("/dev/dxg", F_OK) != 0)
+    return gpus;
+
+  const char* wsl_markers[] = {
+    "/usr/lib/wsl/lib/libcuda.so.1",
+    "/usr/lib/wsl/lib/libcuda.so",
+    "/usr/lib/wsl/lib/nvidia-smi",
+  };
+  for (const char* marker : wsl_markers)
+  {
+    if (access(marker, F_OK) == 0)
+    {
+      GpuInfo gpu;
+      gpu.vendor_id = NVIDIA_VENDOR_ID;
+      gpu.device_id = 0;
+      gpu.name = "NVIDIA GPU (WSL2)";
+      gpus.push_back(std::move(gpu));
+      break;
+    }
+  }
+
+  return gpus;
+}
+
+std::vector<GpuInfo> detect_gpus()
+{
+  auto gpus = detect_gpus_drm();
+  if (!gpus.empty())
+    return gpus;
+
+  gpus = detect_gpus_proc_driver();
+  if (!gpus.empty())
+    return gpus;
+
+  return detect_gpus_wsl();
 }
 
 #elif defined(_WIN32)

--- a/src/python/functional/py_distance.cpp
+++ b/src/python/functional/py_distance.cpp
@@ -52,7 +52,12 @@ namespace
       auto end = sb::end1dValues(fs);
 
 #ifdef BUILD_WITH_CUDA
+      // default_executor().cuda() is null when the CUDA module loaded but no
+      // usable device exists at runtime (e.g. driver mismatch or
+      // CUDA_VISIBLE_DEVICES=""); fall back to the CPU path instead of
+      // dereferencing it in the factory.
       if (cudaFactory && !sb::settings().forceCpu
+          && sb::default_executor().cuda() != nullptr
           && static_cast<size_t>(std::distance(begin, end)) >= sb::settings().cudaThreshold)
       {
         if (sb::settings().deviceVerbose)
@@ -170,6 +175,7 @@ namespace
 
 #ifdef BUILD_WITH_CUDA
       if (cudaFactory && !sb::settings().forceCpu
+          && sb::default_executor().cuda() != nullptr
           && xTotal * yTotal >= sb::settings().cudaThreshold * sb::settings().cudaThreshold)
       {
         if (sb::settings().deviceVerbose)

--- a/src/python/functional/py_inner_product.cpp
+++ b/src/python/functional/py_inner_product.cpp
@@ -45,7 +45,10 @@ namespace
       auto end = sb::end1dValues(fs);
 
 #ifdef BUILD_WITH_CUDA
-      if (!sb::settings().forceCpu && static_cast<size_t>(std::distance(begin, end)) >= sb::settings().cudaThreshold)
+      // See pdist_impl: cuda() is null when the CUDA module loaded but no
+      // usable device exists at runtime -- take the CPU path instead.
+      if (!sb::settings().forceCpu && sb::default_executor().cuda() != nullptr
+          && static_cast<size_t>(std::distance(begin, end)) >= sb::settings().cudaThreshold)
       {
         if (sb::settings().deviceVerbose)
         {

--- a/src/python/functional/py_make_from_serial_content.cpp
+++ b/src/python/functional/py_make_from_serial_content.cpp
@@ -37,9 +37,19 @@ namespace sb_py
       throw std::runtime_error("content should have 2 dimensions (content has shape " + shape_to_string(content) + ").");
     }
 
+    if (content_buf.shape[1] != 2)
+    {
+      throw std::runtime_error("content should have 2 columns, [time, value] (content has shape " + shape_to_string(content) + ").");
+    }
+
     if (enumeration_buf.ndim < 2)
     {
       throw std::runtime_error("enumeration must have at least 2 dimensions");
+    }
+
+    if (enumeration_buf.shape[enumeration_buf.ndim - 1] != 2)
+    {
+      throw std::runtime_error("enumeration's last dimension should have size 2, [start, stop) (enumeration has shape " + shape_to_string(enumeration) + ").");
     }
 
     std::vector<size_t> targetShape(enumeration_buf.ndim - 1);
@@ -52,7 +62,9 @@ namespace sb_py
 
     sb::walk(target, [&target, &content, &enumeration](const std::vector<size_t>& idx) {
 
-      auto enumerationBaseOffset = std::inner_product(idx.begin(), idx.end(), enumeration.strides(), 0_uz);
+      // Signed accumulation: strides are negative for reversed views, and an
+      // unsigned division of the wrapped sum would produce a garbage offset.
+      auto enumerationBaseOffset = std::inner_product(idx.begin(), idx.end(), enumeration.strides(), py::ssize_t{0});
       enumerationBaseOffset /= enumeration.itemsize();
 
       auto* enumerationBuf = enumeration.unchecked().data();

--- a/src/python/py_np_support.hpp
+++ b/src/python/py_np_support.hpp
@@ -30,7 +30,9 @@ std::string shape_to_string(pybind11::array_t<T> arr)
 template <typename T>
 T& get_element(pybind11::array_t<T>& arr, const std::vector<pybind11::ssize_t>& idx)
 {
-  auto offset = std::inner_product(idx.begin(), idx.end(), arr.strides(), 0_uz);
+  // NumPy strides are signed (negative for reversed views), so the offset
+  // must accumulate and divide as a signed quantity.
+  auto offset = std::inner_product(idx.begin(), idx.end(), arr.strides(), pybind11::ssize_t{0});
   offset /= arr.itemsize();
   return *(static_cast<T*>(arr.request().ptr) + offset);
 }
@@ -55,12 +57,14 @@ public:
     return m_arr.shape(i);
   }
 
-  [[nodiscard]] std::vector<size_t> strides() const
+  [[nodiscard]] std::vector<pybind11::ssize_t> strides() const
   {
-    std::vector<size_t> s;
+    // Signed, like sb::Tensor::strides() -- numpy strides are negative for
+    // reversed views and must not be wrapped through size_t.
+    std::vector<pybind11::ssize_t> s;
     s.resize(m_arr.ndim());
     std::transform(m_arr.strides(), m_arr.strides() + m_arr.ndim(), s.begin(), [this](pybind11::ssize_t n) {
-      return static_cast<size_t>(n / m_arr.itemsize());
+      return n / m_arr.itemsize();
     });
     return s;
   }

--- a/src/python/py_tensor.hpp
+++ b/src/python/py_tensor.hpp
@@ -158,8 +158,11 @@ namespace sb_py
           std::transform(self.strides().begin(), self.strides().end(), strides.begin(),
               [](ptrdiff_t v) { return static_cast<pybind11::ssize_t>(v * sizeof(T)); });
 
+          // data() already includes the view offset; adding offset() again
+          // would read past the start of the view (latent until contiguous
+          // zero-copy views land, see tensor.tpp extract()).
           return pybind11::buffer_info(
-              static_cast<void*>(self.data() + self.offset()),
+              static_cast<void*>(self.data()),
               sizeof(T),
               pybind11::format_descriptor<T>::format(),
               self.rank(),

--- a/src/python/pymodule.cpp
+++ b/src/python/pymodule.cpp
@@ -145,6 +145,11 @@ PYBIND11_MODULE(SB_MODULE_NAME, m) {
   m.def("set_min_block_side", [](size_t n){ sb::settings().minBlockSide = n; });
 #ifdef BUILD_WITH_CUDA
   m.def("limit_gpus", [](size_t n){ sb::default_executor().limit_cuda_workers(n); });
+#else
+  // No-op on CPU-only builds, per the Python docstring ("only has an effect
+  // if compiled with GPU support") -- omitting it entirely made
+  // stablebear.system.limit_gpus raise AttributeError instead.
+  m.def("limit_gpus", [](size_t) { });
 #endif
   m.def("get_ngpus", &getNumGpus);
 

--- a/stablebear/_tensor_base.py
+++ b/stablebear/_tensor_base.py
@@ -362,13 +362,17 @@ class Tensor(ABC):
         basic = [slice(None) if isinstance(s, (BoolTensor, IntTensor)) else s
                  for s in entries]
         result = self._basic_getitem(basic, allow_scalar=False)
+        axis_shift = 0
         for orig_pos, idx in advanced:
             dims_dropped = sum(1 for j in range(orig_pos) if isinstance(entries[j], int))
-            axis = orig_pos - dims_dropped
+            axis = orig_pos - dims_dropped + axis_shift
             if isinstance(idx, BoolTensor):
                 result = self._to_py_tensor(result._data.axis_select(axis, idx._data))  # type: ignore[arg-type]
             else:
                 result = self._index_select_nd(result, axis, idx)
+                # A rank-r index array replaces the selected axis with r axes,
+                # so later advanced indices sit r - 1 positions further right.
+                axis_shift += max(idx.ndim, 1) - 1
         return result
 
     def _basic_getitem(self, entries, allow_scalar=True):

--- a/stablebear/gpu.py
+++ b/stablebear/gpu.py
@@ -5,7 +5,9 @@ falling back to a pure-Python implementation using subprocess.
 """
 
 try:
-    from _gpu_detect import detect_nvidia_gpus, has_nvidia_gpu, nvidia_gpu_count
+    # The extension is installed inside the package (site-packages/stablebear/),
+    # so it must be imported relatively; a top-level import never resolves.
+    from ._gpu_detect import detect_nvidia_gpus, has_nvidia_gpu, nvidia_gpu_count
 except ImportError:
     import os
     import platform
@@ -38,10 +40,14 @@ except ImportError:
         if gpus:
             return gpus
 
-        # Fallback: check sysfs for NVIDIA vendor ID (0x10de)
+        # Fallback: check sysfs for NVIDIA vendor ID (0x10de). Each physical
+        # GPU exposes several drm nodes (cardN, renderDN, connectors); count
+        # only the cardN nodes to avoid double-counting.
         drm_path = "/sys/class/drm"
         if os.path.isdir(drm_path):
             for entry in os.listdir(drm_path):
+                if not re.fullmatch(r"card\d+", entry):
+                    continue
                 vendor_file = os.path.join(drm_path, entry, "device", "vendor")
                 if os.path.isfile(vendor_file):
                     try:
@@ -51,6 +57,40 @@ except ImportError:
                             gpus.append({"name": "NVIDIA GPU"})
                     except OSError:
                         pass
+
+        if gpus:
+            return gpus
+
+        # Fallback: the driver's procfs (one directory per GPU). Covers slim
+        # containers without lspci or drm entries.
+        nvidia_proc = "/proc/driver/nvidia/gpus"
+        if os.path.isdir(nvidia_proc):
+            for entry in sorted(os.listdir(nvidia_proc)):
+                name = "NVIDIA GPU [" + entry + "]"
+                info_file = os.path.join(nvidia_proc, entry, "information")
+                try:
+                    with open(info_file) as f:
+                        for line in f:
+                            if line.startswith("Model:"):
+                                name = line[len("Model:"):].strip()
+                                break
+                except OSError:
+                    pass
+                gpus.append({"name": name})
+
+        if gpus:
+            return gpus
+
+        # Fallback: WSL2 exposes the GPU through /dev/dxg with no NVIDIA PCI
+        # drm nodes and no useful lspci. /dev/dxg alone could be any vendor,
+        # so require the WSL NVIDIA driver libraries as well.
+        if os.path.exists("/dev/dxg"):
+            wsl_lib = "/usr/lib/wsl/lib"
+            if any(
+                os.path.exists(os.path.join(wsl_lib, lib))
+                for lib in ("libcuda.so.1", "libcuda.so", "nvidia-smi")
+            ):
+                gpus.append({"name": "NVIDIA GPU (WSL2)"})
 
         return gpus
 

--- a/stablebear/reductions.py
+++ b/stablebear/reductions.py
@@ -71,6 +71,9 @@ def mean(fs: PcfContainerLike, dim: int = 0):
     ------
     IndexError
         If ``dim`` is out of range for the input tensor's number of dimensions.
+    ValueError
+        If the reduced dimension has size 0 (the mean of zero functions is
+        undefined).
     """
     backend, tensor = _resolve_pcf_inputs(_REDUCTIONS_BACKEND_MAP, fs)
     return _to_tensor(backend.mean(tensor._data, _resolve_dim(dim, tensor.ndim)))

--- a/test/python/test_advanced_indexing.py
+++ b/test/python/test_advanced_indexing.py
@@ -210,6 +210,35 @@ class TestMultipleIntIndices:
         arr = np.arange(20, dtype=np.float32).reshape(4, 5)
         _assert_outer_index(arr, (np.array([1, 3]), slice(1, 4)))
 
+    def test_2d_index_array_then_1d(self):
+        # Regression for #182: a rank-2 index array inserts two output axes,
+        # so the next advanced index must shift right by one; it used to be
+        # applied to an axis of the first index array instead.
+        arr = np.arange(12, dtype=np.float32).reshape(3, 4)
+        result = np.asarray(_sb(arr)[np.array([[0, 1], [1, 0]]), np.array([1])])
+        expected = arr[np.array([[0, 1], [1, 0]])][:, :, [1]]
+        assert result.shape == (2, 2, 1)
+        np.testing.assert_array_equal(result, expected)
+
+    def test_two_2d_index_arrays_outer(self):
+        arr = np.arange(12, dtype=np.float32).reshape(3, 4)
+        rows = np.array([[0, 1], [2, 0]])
+        cols = np.array([[1, 3], [0, 2]])
+        result = np.asarray(_sb(arr)[rows, cols])
+        # Outer semantics: each rank-2 index contributes its own two axes.
+        expected = arr[rows][..., cols]
+        assert result.shape == (2, 2, 2, 2)
+        np.testing.assert_array_equal(result, expected)
+
+    def test_1d_then_2d_index_array(self):
+        arr = np.arange(12, dtype=np.float32).reshape(3, 4)
+        rows = np.array([2, 0])
+        cols = np.array([[1, 3], [0, 2]])
+        result = np.asarray(_sb(arr)[rows, cols])
+        expected = arr[rows][:, cols]
+        assert result.shape == (2, 2, 2)
+        np.testing.assert_array_equal(result, expected)
+
 
 class TestMixedBoolIntIndices:
     def test_bool_rows_int_cols(self):

--- a/test/python/test_bugscan_inplace_alias.py
+++ b/test/python/test_bugscan_inplace_alias.py
@@ -1,0 +1,63 @@
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+import stablebear as sb
+from stablebear.base_tensor import FloatTensor, IntTensor
+
+
+# ---------------------------------------------------------------------------
+# Bug #191: in-place tensor arithmetic ignored LHS/RHS aliasing. When the RHS
+# is a view of the same buffer (a[1:] += a[:-1], a += a[::-1]), the in-place
+# walk read elements it had already updated, producing traversal-order-
+# dependent results. NumPy materializes the RHS first; so do we now.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("np_dtype,TensorT", [(np.float32, FloatTensor),
+                                              (np.float64, FloatTensor),
+                                              (np.int32, IntTensor),
+                                              (np.int64, IntTensor)])
+class TestInplaceAliasing:
+    def test_shifted_overlap_add(self, np_dtype, TensorT):
+        a = TensorT(np.array([1, 2, 3, 4], dtype=np_dtype))
+        a[1:] += a[:-1]
+        expected = np.array([1, 2, 3, 4], dtype=np_dtype)
+        expected[1:] = expected[1:] + expected[:-1].copy()
+        npt.assert_array_equal(np.asarray(a), expected)  # [1, 3, 5, 7]
+
+    def test_reversed_self_add(self, np_dtype, TensorT):
+        a = TensorT(np.array([1, 2, 3, 4], dtype=np_dtype))
+        a += a[::-1]
+        npt.assert_array_equal(np.asarray(a), [5, 5, 5, 5])
+
+    def test_shifted_overlap_mul(self, np_dtype, TensorT):
+        a = TensorT(np.array([1, 2, 3, 4], dtype=np_dtype))
+        a[1:] *= a[:-1]
+        npt.assert_array_equal(np.asarray(a), [1, 2, 6, 12])
+
+    def test_2d_row_overlap(self, np_dtype, TensorT):
+        arr = np.arange(1, 7, dtype=np_dtype).reshape(3, 2)
+        a = TensorT(arr.copy())
+        a[1:] += a[:-1]
+        expected = arr.copy()
+        expected[1:] = expected[1:] + expected[:-1].copy()
+        npt.assert_array_equal(np.asarray(a), expected)
+
+    def test_non_aliasing_unaffected(self, np_dtype, TensorT):
+        a = TensorT(np.array([1, 2, 3, 4], dtype=np_dtype))
+        b = TensorT(np.array([10, 20, 30, 40], dtype=np_dtype))
+        a += b
+        npt.assert_array_equal(np.asarray(a), [11, 22, 33, 44])
+
+
+def test_pcf_tensor_shifted_overlap_add():
+    """Aliasing handling must also hold for PCF elements."""
+    X = sb.zeros((3,))
+    X[0] = sb.Pcf(np.array([[0.0, 1.0]], dtype=np.float32))
+    X[1] = sb.Pcf(np.array([[0.0, 2.0]], dtype=np.float32))
+    X[2] = sb.Pcf(np.array([[0.0, 4.0]], dtype=np.float32))
+
+    X[1:] += X[:-1]
+
+    npt.assert_array_equal(np.asarray(X(0.0)), [1.0, 3.0, 6.0])

--- a/test/python/test_bugscan_reductions.py
+++ b/test/python/test_bugscan_reductions.py
@@ -94,10 +94,11 @@ def test_max_time_empty_reduced_axis_raises_not_segfault():
     """max_time over a size-0 reduced axis must raise cleanly, never SIGSEGV.
 
     Issue #25 (bug scan): ``max_time`` segfaulted on an empty reduction
-    dimension while ``mean`` handled it. Resolved together with #46 —
-    ``max_element`` now rejects an empty reduction range with ``ValueError``
-    (``max`` has no identity over an empty range). ``mean`` still returns a
-    valid reduced tensor over the same empty axes, so the two stay consistent.
+    dimension. Resolved together with #46 — ``max_element`` now rejects an
+    empty reduction range with ``ValueError`` (``max`` has no identity over
+    an empty range). Issue #196: ``mean`` used to divide by zero on the same
+    input and silently return all-NaN PCFs; it now raises the same
+    ``ValueError``, so the two stay consistent.
     """
     # 1-D empty tensor reduced along its only (empty) axis.
     with pytest.raises(ValueError):
@@ -105,6 +106,8 @@ def test_max_time_empty_reduced_axis_raises_not_segfault():
     # Empty inner dimension of a higher-rank tensor.
     with pytest.raises(ValueError):
         sb.max_time(sb.zeros((3, 0)), dim=1)
-    # Contrast: mean returns a valid reduced tensor over the same empty axes.
-    assert sb.mean(sb.zeros((0,)), dim=0).shape == (1,)
-    assert sb.mean(sb.zeros((3, 0)), dim=1).shape == (3,)
+    # mean raises the same clean error instead of silently returning NaN PCFs.
+    with pytest.raises(ValueError):
+        sb.mean(sb.zeros((0,)), dim=0)
+    with pytest.raises(ValueError):
+        sb.mean(sb.zeros((3, 0)), dim=1)

--- a/test/python/test_from_serial_content.py
+++ b/test/python/test_from_serial_content.py
@@ -118,6 +118,64 @@ def test_fsc_negative_start_raises(dtype):
         sb.from_serial_content(content, enumeration)
 
 
+def test_fsc_content_wrong_trailing_dim_raises():
+    """content with anything but 2 columns must raise, not read past each row.
+
+    Regression for #193: content of shape (N, 1) read one element past every
+    row (heap over-read) instead of raising a shape error.
+    """
+    enumeration = np.array([[0, 2]], dtype=np.int64)
+    with pytest.raises(RuntimeError):
+        sb.from_serial_content(np.zeros((5, 1)), enumeration)
+    with pytest.raises(RuntimeError):
+        sb.from_serial_content(np.zeros((5, 3)), enumeration)
+
+
+def test_fsc_enumeration_wrong_trailing_dim_raises():
+    """enumeration whose last dim is not 2 must raise, not read stop OOB.
+
+    Regression for #193.
+    """
+    content = np.array([[0.0, 1.0], [2.0, 3.0]])
+    with pytest.raises(RuntimeError):
+        sb.from_serial_content(content, np.zeros((3, 1), dtype=np.int64))
+    with pytest.raises(RuntimeError):
+        sb.from_serial_content(content, np.zeros((3, 3), dtype=np.int64))
+
+
+def test_fsc_negative_stride_content():
+    """A reversed (negative-stride) content view must read the right rows.
+
+    Regression for #194: unsigned stride arithmetic wrapped the negative
+    stride to ~2^64, producing garbage offsets (OOB reads).
+    """
+    content = np.array([[0.0, 1.0], [0.0, 2.0], [0.0, 3.0], [0.0, 4.0]])
+    rev = content[::-1]
+    assert rev.strides[0] < 0
+    enumeration = np.array([[0, 1], [1, 2], [2, 3], [3, 4]], dtype=np.int64)
+
+    X = sb.from_serial_content(rev, enumeration)
+
+    for i in range(4):
+        assert X[i] == sb.Pcf(np.array([[0.0, 4.0 - i]]))
+
+
+def test_fsc_negative_stride_enumeration():
+    """A reversed (negative-stride) enumeration view must read the right items.
+
+    Regression for #194 (the enumeration base-offset accumulation).
+    """
+    content = np.array([[0.0, 10.0], [10.0, 20.0], [0.0, 50.0], [10.0, 60.0]])
+    enumeration = np.array([[0, 2], [2, 4]], dtype=np.int64)
+    rev = enumeration[::-1]
+    assert rev.strides[0] < 0
+
+    X = sb.from_serial_content(content, rev)
+
+    assert X[0] == sb.Pcf(content[2:4])
+    assert X[1] == sb.Pcf(content[0:2])
+
+
 def test_fsc_stop_equals_length_ok():
     """stop == content.shape(0) is in-bounds and must still succeed."""
     content = np.array([[0.0, 10.0], [10.0, 20.0], [20.0, 30.0]])

--- a/test/python/test_pcf_tensor_eval.py
+++ b/test/python/test_pcf_tensor_eval.py
@@ -130,6 +130,29 @@ class TestPcfTensorEvalArray:
         assert result.shape == (2, 2)
         npt.assert_array_almost_equal(result, [[1, 5], [3, 1]])
 
+    def test_empty_times_array(self, dtypes):
+        # Regression for issue #192: an empty evaluation grid used to hit
+        # undefined behavior instead of returning an empty result.
+        pcf_dtype, np_dtype = dtypes
+        X = make_1d_tensor(pcf_dtype, np_dtype)
+        result = X(np.array([], dtype=np_dtype))
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (2, 0)
+
+    def test_empty_times_list(self, dtypes):
+        pcf_dtype, np_dtype = dtypes
+        X = make_2d_tensor(pcf_dtype, np_dtype)
+        result = X([])
+        assert result.shape == (2, 2, 0)
+
+    @pytest.mark.parametrize("float_dtype", [np.float32, np.float64])
+    def test_empty_float_tensor_input(self, dtypes, float_dtype):
+        pcf_dtype, np_dtype = dtypes
+        X = make_1d_tensor(pcf_dtype, np_dtype)
+        t = sb.FloatTensor(np.array([], dtype=float_dtype))
+        result = X(t)
+        assert result.shape == (2, 0)
+
 
 class TestPcfTensorEvalParallel:
     """Verify that parallel tensor_eval produces correct results.

--- a/test/test_bugscan_core.cpp
+++ b/test/test_bugscan_core.cpp
@@ -1,0 +1,115 @@
+// Regression tests for issue #196 (low-severity C++ core defects).
+
+#include <gtest/gtest.h>
+
+#include <sbear/functional/pcf.hpp>
+#include <sbear/algorithms/functional/matrix_reduce.hpp>
+#include <sbear/persistence/barcode.hpp>
+#include <sbear/persistence/betti_curve.hpp>
+#include <sbear/persistence/accumulated_persistence.hpp>
+#include <sbear/tensor.hpp>
+
+#include <stdexcept>
+#include <vector>
+
+namespace
+{
+
+  // --------------------------------------------------------------------------
+  // Empty PCFs are invalid: evaluate/iterate_rectangles dereference the first
+  // point unconditionally, so the constructor must reject an empty vector.
+  // --------------------------------------------------------------------------
+
+  TEST(BugscanCore, EmptyPcfConstructionThrows)
+  {
+    std::vector<sb::Pcf_f64::point_type> pts;
+    EXPECT_THROW(sb::Pcf_f64(std::move(pts)), std::invalid_argument);
+  }
+
+  // --------------------------------------------------------------------------
+  // mean() over a zero-length dimension used to divide by zero and silently
+  // return all-NaN PCFs; it must throw like max_element does.
+  // --------------------------------------------------------------------------
+
+  TEST(BugscanCore, MeanOverEmptyDimensionThrows)
+  {
+    sb::Tensor<sb::Pcf_f64> t({ 0, 3 });
+    EXPECT_THROW(sb::mean(t, 0), std::invalid_argument);
+
+    sb::Tensor<sb::Pcf_f64> t2({ 3, 0 });
+    EXPECT_THROW(sb::mean(t2, 1), std::invalid_argument);
+  }
+
+  TEST(BugscanCore, MeanOverNonEmptyDimensionStillWorks)
+  {
+    sb::Tensor<sb::Pcf_f64> t({ 2 });
+    t({ 0ul }) = sb::Pcf_f64(2.0);
+    t({ 1ul }) = sb::Pcf_f64(4.0);
+
+    auto m = sb::mean(t, 0);
+    ASSERT_EQ(m.size(), 1u);
+    EXPECT_EQ(m({ 0ul }).points()[0].v, 3.0);
+  }
+
+  // --------------------------------------------------------------------------
+  // Barcode summaries with negative event times (sublevel-set filtrations)
+  // used to emit a (0, 0) breakpoint followed by earlier negative times -- an
+  // unsorted PCF. The breakpoints must come out strictly increasing.
+  // --------------------------------------------------------------------------
+
+  template <typename PcfT>
+  void expect_strictly_increasing(const PcfT& f)
+  {
+    auto const& pts = f.points();
+    ASSERT_FALSE(pts.empty());
+    for (size_t i = 1; i < pts.size(); ++i)
+    {
+      EXPECT_LT(pts[i - 1].t, pts[i].t) << "breakpoints out of order at index " << i;
+    }
+  }
+
+  TEST(BugscanCore, BettiCurveWithNegativeBirthsIsSorted)
+  {
+    using T = sb::float64_t;
+    sb::ph::Barcode<T> barcode(std::vector<sb::ph::PersistencePair<T>>{
+        sb::ph::PersistencePair<T>(-2.0, -0.5),
+        sb::ph::PersistencePair<T>(-1.0, 1.0),
+        sb::ph::PersistencePair<T>(0.5, 2.0) });
+
+    auto f = sb::ph::barcode_to_betti_curve(barcode);
+    expect_strictly_increasing(f);
+
+    // Curve starts at the earliest birth, and the value on [0, inf) -- the
+    // PCF evaluation domain -- is correct instead of corrupt: at t = 0 the
+    // alive bars are (-1, 1) and (0.5 is not yet born), so count is 1.
+    EXPECT_EQ(f.points().front().t, -2.0);
+    EXPECT_EQ(f.evaluate(0.0), 1.0);  // bar (-1, 1) alive
+    EXPECT_EQ(f.evaluate(0.75), 2.0); // bars (-1, 1) and (0.5, 2) alive
+  }
+
+  TEST(BugscanCore, BettiCurveWithNonNegativeBirthsStillStartsAtZero)
+  {
+    using T = sb::float64_t;
+    sb::ph::Barcode<T> barcode(std::vector<sb::ph::PersistencePair<T>>{
+        sb::ph::PersistencePair<T>(1.0, 2.0) });
+
+    auto f = sb::ph::barcode_to_betti_curve(barcode);
+    expect_strictly_increasing(f);
+    EXPECT_EQ(f.points().front().t, 0.0);
+    EXPECT_EQ(f.evaluate(0.5), 0.0);
+    EXPECT_EQ(f.evaluate(1.5), 1.0);
+  }
+
+  TEST(BugscanCore, AccumulatedPersistenceWithNegativeMidpointsIsSorted)
+  {
+    using T = sb::float64_t;
+    sb::ph::Barcode<T> barcode(std::vector<sb::ph::PersistencePair<T>>{
+        sb::ph::PersistencePair<T>(-3.0, -1.0),
+        sb::ph::PersistencePair<T>(-1.0, 2.0) });
+
+    auto f = sb::ph::barcode_to_accumulated_persistence(barcode);
+    expect_strictly_increasing(f);
+    EXPECT_EQ(f.points().front().t, -2.0); // earliest midpoint
+  }
+
+} // namespace

--- a/test/test_parallel_reduce.cpp
+++ b/test/test_parallel_reduce.cpp
@@ -17,3 +17,22 @@ TEST(ParallelReduce, AddThreeFunctions)
 
   EXPECT_EQ(res, (pcfs[0] + pcfs[1] + pcfs[2]));
 }
+
+// Regression for issue #186: an empty range used to reach subdivide's
+// SIZE_MAX-wrapped block and read far out of bounds.
+TEST(ParallelReduce, EmptyRangeThrows)
+{
+  std::vector<sb::Pcf_f64> pcfs;
+
+  auto op = [](const typename sb::Pcf_f64::rectangle_type& rect) {
+    return rect.f_value + rect.g_value;
+  };
+
+  EXPECT_THROW(sb::parallel_reduce(pcfs.begin(), pcfs.end(), op), std::invalid_argument);
+}
+
+TEST(ParallelReduce, AverageOfEmptyVectorThrows)
+{
+  std::vector<sb::Pcf_f64> pcfs;
+  EXPECT_THROW(sb::average(pcfs), std::invalid_argument);
+}

--- a/test/test_subdivide.cpp
+++ b/test/test_subdivide.cpp
@@ -45,6 +45,17 @@ namespace
     }
   }
 
+  TEST(Subdivide, NoItems)
+  {
+    // Regression: nItems == 0 used to clamp the first block's end to
+    // nItems - 1, wrapping to SIZE_MAX (issue #186).
+    for (size_t bs = 1; bs <= 5; ++bs)
+    {
+      auto blocks = sb::subdivide(bs, 0);
+      EXPECT_TRUE(blocks.empty());
+    }
+  }
+
   TEST(Subdivide, SingleItem)
   {
     auto blocks = sb::subdivide(5, 1);

--- a/test/test_tensor.cpp
+++ b/test/test_tensor.cpp
@@ -108,11 +108,22 @@ namespace
 
 // size()
 
-  TYPED_TEST(TensorTppTyped, SizeOfEmptyTensor)
+  TYPED_TEST(TensorTppTyped, SizeOfRankZeroTensorIsOne)
   {
+    // A rank-0 tensor holds exactly one element (numpy convention); size()
+    // must agree with walk() and get_total_size() (issue #196).
     using T = TypeParam;
     sb::Tensor<T> t;
+    EXPECT_EQ(t.size(), 1u);
+  }
+
+  TYPED_TEST(TensorTppTyped, SizeOfZeroExtentTensorIsZero)
+  {
+    using T = TypeParam;
+    sb::Tensor<T> t({ 0 });
     EXPECT_EQ(t.size(), 0u);
+    sb::Tensor<T> t2({ 3, 0 });
+    EXPECT_EQ(t2.size(), 0u);
   }
 
   TYPED_TEST(TensorTppTyped, Size1d)


### PR DESCRIPTION
Fixes the race-condition/crash issues from the 2026-07-01 bug scan, the next tier of memory-safety and silent-corruption bugs, and the remaining non-Python code/build/CI bugs — one commit per issue (closely-related issues share a commit).

## Batch 1 — crashes and race conditions

- **#189 (high) — multi-GPU data race**: `CudaOffsetDataManager::upload_subset` resized and wrote a shared `mutable` scratch vector from all GPU worker threads with no synchronization, producing torn offset tables (silently wrong distance matrices or OOB kernel reads) on 2+ GPU machines. The scratch buffer is now a local variable.
- **#188 (high) — CUDA errors silently swallowed**: `CudaBlockPipeline::execute` discarded the `tf::Future` from `run()` and used `wait_for_all()`, which does not rethrow task exceptions — a mid-computation CUDA failure (e.g. device OOM) returned a partially-zero matrix with no error. Now the future is retained and `.get()` rethrows into the outer task future that `StoppableTask::wait_for` already propagates to Python.
- **#187 (high) — segfault with zero usable CUDA devices**: all three CUDA dispatch sites (`pdist`/`cdist`/`l2_kernel`) now check `default_executor().cuda() != nullptr` and fall back to the CPU path instead of dereferencing null when the CUDA module loads but no device is usable at runtime.
- **#186 (high) — out-of-bounds read on empty reduce**: `subdivide(bs, 0)` clamped the first block's end to `nItems - 1`, wrapping to `SIZE_MAX`, so `parallel_reduce`/`average` on an empty range read ~2^64 elements out of bounds. `subdivide` now returns no blocks for zero items, and `parallel_reduce` rejects an empty range with `std::invalid_argument` (a Python `ValueError`).
- **#192 (medium) — UB on empty evaluation grid**: `T(np.array([]))` now returns an empty result of shape `T.shape + (0,)` per numpy convention instead of indexing `domain_indices[0]` on an empty vector.

## Batch 2 — memory safety and silent corruption

- **#193/#194 (medium) — `from_serial_content` OOB reads**: trailing dimensions are now validated (`content` must have 2 columns, `enumeration`'s last dim must be 2 — previously heap over-reads), and the stride arithmetic in `get_element`/the enumeration base offset now accumulates and divides as signed, so reversed (negative-stride) numpy views read the right elements instead of wrapping to ~2^64 offsets. `NumpyTensor::strides()` is now signed, like `sb::Tensor::strides()`.
- **#191 (medium) — in-place arithmetic aliasing**: `a[1:] += a[:-1]` / `a += a[::-1]` silently produced traversal-order-dependent results because `broadcast_binop_inplace` never checked for a shared buffer. It now detects aliasing (same check as `assign_from`) and materializes the RHS first, matching NumPy.
- **#182 (medium) — advanced indexing on the wrong axis**: with multiple advanced indices where one has rank > 1, subsequent indices were applied at a stale axis position (silently wrong data or spurious `IndexError`). The axis shift from inserted dimensions is now tracked.
- **#190 (medium, latent) — GPU/CPU divergence for custom bounds**: the device-side rectangle iteration now starts at the last breakpoint ≤ `a` (device binary search mirroring `max_time_iterator_prior_to`) and clamps rectangle ends to `b`, exactly like the CPU reference. Behavior for the default `(0, max)` bounds used by the bindings is unchanged.
- **#173 (high) — `_gpu_detect` dead code**: `gpu.py` imported the extension as a top-level module while it is installed inside the package, so the compiled detector never ran and the subprocess fallback silently took over (missing GPUs in slim containers). Now imported relatively; also fixed the DRM `cardN`/`renderDN` double-count in both the C++ module and the Python fallback, and added `/proc/driver/nvidia/gpus` and WSL2 (`/dev/dxg` + WSL driver libs) detection to both.

## Batch 3 — remaining code/build/CI bugs

- **#195 (medium) — Ctrl-C couldn't interrupt CUDA**: `CudaBlockPipeline::cancel()` existed but had no call sites, so `request_stop()` during a GPU `pdist` blocked until the whole matrix finished. The pipeline now polls a stop predicate per block; the CUDA tasks pass `StoppableTask::stop_requested()`, so interruption takes effect at block granularity like the CPU path.
- **#196 (low) — core defects**: `mean()` over a size-0 dimension raises a clean `ValueError` instead of silently returning all-NaN PCFs; empty PCFs are rejected at construction (previously UB in `evaluate`/`iterate_rectangles`, reachable from truncated files) and `read_element` validates strictly-increasing breakpoint times; the betti-curve and accumulated-persistence summaries handle negative event times (sublevel-set filtrations) by starting at the earliest event instead of emitting unsorted PCFs; `Tensor::size()` returns 1 for rank-0 tensors, agreeing with `walk()`/`get_total_size()` and the Python-facing `.size`.
- **#197 (low) — binding defects**: `limit_gpus` is now bound as a documented no-op on CPU-only builds instead of raising `AttributeError`; the buffer protocol no longer adds `offset()` to `data()` (which already includes it) — a latent double-offset.
- **#168/#170 (medium/low) — CMake**: warning flags append to `CMAKE_CXX_FLAGS` instead of discarding user/packager `CXXFLAGS`; `message(FATAL)` → `FATAL_ERROR`; `VERSION_INFO` now uses the actually-set `PROJ_VERSION_FULL`; `PROJECT_TITLE` is set for `version.cpp.in` (so `sb::PROJECT_TITLE` is no longer empty); the configure log prints `SKIP_STUBGEN` instead of the never-set `STUB_FILE`.
- **#162/#163 (high/medium) — CI**: `publish-pypitest.yaml` downloads the merged `wheels` artifact instead of the nonexistent `cpu-wheels` (TestPyPI publishing was impossible); `CODECOV_TOKEN` is declared in `analysis.yaml`'s `workflow_call` and passed from `ci.yaml` and both publish workflows (uploads previously ran tokenless on every PR/publish pipeline).

Intentionally left out per request (pure Python): #183, #184, #185, #198. Also untouched: docs-only issues (#174–#178, #199), broken examples/benchmarks/notebook (#179–#181), and CI/infra friction items (#164–#167, #169, #171–#172).

## Tests

- New C++ regression tests (`test_bugscan_core.cpp` and additions to existing files): empty-`subdivide`, empty `parallel_reduce`/`average`, empty-Pcf construction, `mean` over empty dims, betti/APF with negative event times, rank-0 `size()`. Full C++ suite: 416/416 pass.
- New Python regression tests: empty-grid evaluation, `from_serial_content` shape validation and negative-stride inputs, in-place aliasing, multi-advanced-index gathers with rank-2 arrays. Full Python suite: 1827 pass, 31 skipped. One pre-existing test asserting `mean`'s silent empty-dim behavior was updated to expect the new `ValueError`.
- The #182 and #190 fixes were additionally verified to fail against the unfixed code (test-level and via a 20k-case fuzz harness comparing the extracted device iteration against the CPU reference, respectively).
- `_gpu_detect` now actually loads, and `limit_gpus` was exercised as a no-op on the CPU-only build.

## Verification limits

No GPU or CUDA toolkit is available in the sandbox, so the CUDA-path changes (#187–#190, #195) were not executed on a device. They were verified by syntax checks, review of the exception-propagation chain (per the contract documented in `task.hpp`), and the host-side fuzz equivalence check above. A run on a GPU machine (ideally multi-GPU for #189) before release is recommended. The workflow YAML changes (#162/#163) parse cleanly but will only prove out on the next CI/publish run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017nGFonEvMk39UBWvqQS3HY