### PR TITLE
Fix CUDA pipeline robustness: data race, swallowed exceptions, null-deref, uninterruptible runs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -887,6 +887,7 @@ if (BUILD_TESTER)
         test/test_block_matrix_support.cu
         test/test_l1_dist.cu
         test/test_block_integrate.cu
+        test/test_cuda_block_pipeline.cu
         test/test_norms.cu
         ${SB_TEST_SOURCES_COMMON}
     )

--- a/include/sbear/cuda/cuda_block_executor.cuh
+++ b/include/sbear/cuda/cuda_block_executor.cuh
@@ -140,8 +140,10 @@ namespace sb
         exec_block(blocks[i], blockDim);
       });
 
-      m_gpuThreads.run(std::move(flow));
-      m_gpuThreads.wait_for_all();
+      // wait_for_all() discards task exceptions; get() rethrows the first
+      // CHK_CUDA failure (OOM, bad launch, ...) so it reaches the caller
+      // instead of silently leaving the remaining blocks zeroed.
+      m_gpuThreads.run(std::move(flow)).get();
 
       // Flush any pending scatter on each GPU
       for (size_t iGpu = 0; iGpu < m_nGpus; ++iGpu)

--- a/include/sbear/cuda/cuda_block_executor.cuh
+++ b/include/sbear/cuda/cuda_block_executor.cuh
@@ -114,12 +114,14 @@ namespace sb
         BlockOp& blockOp,
         const CudaBlockScheduler& scheduler,
         ResultWriter& writer,
-        std::function<void(size_t)> progressCb = [](size_t) {})
+        std::function<void(size_t)> progressCb = [](size_t) {},
+        std::function<bool()> stopRequested = [] { return false; })
       : m_gpuThreads(gpuThreads)
       , m_blockOp(blockOp)
       , m_scheduler(scheduler)
       , m_writer(writer)
       , m_progressCb(progressCb)
+      , m_stopRequested(stopRequested)
       , m_nGpus(gpuThreads.num_workers())
     {
       m_canceled.store(false);
@@ -133,7 +135,10 @@ namespace sb
 
       tf::Taskflow flow;
       flow.for_each_index<size_t, size_t, size_t>(0ul, blocks.size(), 1ul, [this, &blocks, blockDim](size_t i) {
-        if (m_canceled.load())
+        // Checked per block so a stop request (e.g. Ctrl-C via
+        // StoppableTask::request_stop) interrupts a running computation at
+        // block granularity instead of after the whole matrix.
+        if (m_canceled.load() || m_stopRequested())
         {
           return;
         }
@@ -336,6 +341,7 @@ namespace sb
     const CudaBlockScheduler& m_scheduler;
     ResultWriter& m_writer;
     std::function<void(size_t)> m_progressCb;
+    std::function<bool()> m_stopRequested;
     size_t m_nGpus;
 
     std::vector<GpuBlockStorage> m_gpuStorages;

--- a/include/sbear/cuda/cuda_offset_data_manager.cuh
+++ b/include/sbear/cuda/cuda_offset_data_manager.cuh
@@ -33,18 +33,17 @@ namespace sb
       size_t baseOffset = hostData.offsets[start];
       size_t nElements = hostData.offsets[start + count] - baseOffset;
 
-      m_localOffsets.resize(count + 1);
+      // Local scratch: one manager instance is shared by all GPU worker
+      // threads, so this must not be shared mutable state.
+      std::vector<size_t> localOffsets(count + 1);
       for (size_t i = 0; i <= count; ++i)
       {
-        m_localOffsets[i] = hostData.offsets[start + i] - baseOffset;
+        localOffsets[i] = hostData.offsets[start + i] - baseOffset;
       }
 
-      deviceOffsets.toDevice(m_localOffsets.data(), count + 1);
+      deviceOffsets.toDevice(localOffsets.data(), count + 1);
       deviceElements.toDevice(hostData.elements.data() + baseOffset, nElements);
     }
-
-  private:
-    mutable std::vector<size_t> m_localOffsets;
   };
 }
 

--- a/include/sbear/cuda/pcf_block_op.cuh
+++ b/include/sbear/cuda/pcf_block_op.cuh
@@ -181,7 +181,8 @@ namespace sb
 
         CudaBlockPipeline<value_type, block_op_t, ResultWriter> pipeline(
             m_cudaThreads, blockOp, scheduler, m_writer,
-            [this](size_t n) { add_progress(n); });
+            [this](size_t n) { add_progress(n); },
+            [this] { return stop_requested(); });
 
         if (stop_requested()) return;
         pipeline.execute(blockDim);
@@ -263,7 +264,8 @@ namespace sb
 
         CudaBlockPipeline<value_type, block_op_t, ResultWriter> pipeline(
             m_cudaThreads, blockOp, scheduler, m_writer,
-            [this](size_t n) { add_progress(n); });
+            [this](size_t n) { add_progress(n); },
+            [this] { return stop_requested(); });
 
         if (stop_requested()) return;
         pipeline.execute(blockDim);

--- a/src/python/functional/py_distance.cpp
+++ b/src/python/functional/py_distance.cpp
@@ -52,7 +52,12 @@ namespace
       auto end = sb::end1dValues(fs);
 
 #ifdef BUILD_WITH_CUDA
+      // default_executor().cuda() is null when the CUDA module loaded but no
+      // usable device exists at runtime (e.g. driver mismatch or
+      // CUDA_VISIBLE_DEVICES=""); fall back to the CPU path instead of
+      // dereferencing it in the factory.
       if (cudaFactory && !sb::settings().forceCpu
+          && sb::default_executor().cuda() != nullptr
           && static_cast<size_t>(std::distance(begin, end)) >= sb::settings().cudaThreshold)
       {
         if (sb::settings().deviceVerbose)
@@ -170,6 +175,7 @@ namespace
 
 #ifdef BUILD_WITH_CUDA
       if (cudaFactory && !sb::settings().forceCpu
+          && sb::default_executor().cuda() != nullptr
           && xTotal * yTotal >= sb::settings().cudaThreshold * sb::settings().cudaThreshold)
       {
         if (sb::settings().deviceVerbose)

--- a/src/python/functional/py_inner_product.cpp
+++ b/src/python/functional/py_inner_product.cpp
@@ -45,7 +45,10 @@ namespace
       auto end = sb::end1dValues(fs);
 
 #ifdef BUILD_WITH_CUDA
-      if (!sb::settings().forceCpu && static_cast<size_t>(std::distance(begin, end)) >= sb::settings().cudaThreshold)
+      // See pdist_impl: cuda() is null when the CUDA module loaded but no
+      // usable device exists at runtime -- take the CPU path instead.
+      if (!sb::settings().forceCpu && sb::default_executor().cuda() != nullptr
+          && static_cast<size_t>(std::distance(begin, end)) >= sb::settings().cudaThreshold)
       {
         if (sb::settings().deviceVerbose)
         {

--- a/test/test_cuda_block_pipeline.cu
+++ b/test/test_cuda_block_pipeline.cu
@@ -1,0 +1,148 @@
+// Regression tests for the CUDA block pipeline (issues #188 and #195):
+// - exceptions thrown inside exec_block must propagate out of execute()
+//   instead of being swallowed by wait_for_all (issue #188);
+// - a stop request must interrupt the pipeline at block granularity
+//   (issue #195), and cancel() must keep working.
+//
+// Uses stub BlockOps against the real pipeline so the behavior is exercised
+// without depending on kernel contents. Requires a CUDA device (the pipeline
+// allocates device buffers up front).
+
+#include <gtest/gtest.h>
+
+#ifdef BUILD_WITH_CUDA
+
+#include <sbear/cuda/cuda_block_executor.cuh>
+#include <sbear/cuda/cuda_block_scheduler.hpp>
+#include <sbear/executor.hpp>
+
+#include <atomic>
+#include <stdexcept>
+
+namespace
+{
+
+  struct NullWriter
+  {
+    void scatter(const float*, const sb::BlockInfo&) {}
+  };
+
+  // exec_block launches nothing; it just counts invocations.
+  struct CountingBlockOp
+  {
+    struct GpuStorage {};
+
+    GpuStorage init_gpu_storage(size_t, const sb::CudaBlockScheduler&) { return {}; }
+
+    void exec_block(GpuStorage&, const sb::BlockInfo&, sb::CudaDeviceArray<float>&, dim3)
+    {
+      ++calls;
+    }
+
+    std::atomic<int> calls{0};
+  };
+
+  struct ThrowingBlockOp
+  {
+    struct GpuStorage {};
+
+    GpuStorage init_gpu_storage(size_t, const sb::CudaBlockScheduler&) { return {}; }
+
+    void exec_block(GpuStorage&, const sb::BlockInfo&, sb::CudaDeviceArray<float>&, dim3)
+    {
+      throw std::runtime_error("simulated CUDA failure");
+    }
+  };
+
+  class CudaBlockPipelineTest : public ::testing::Test
+  {
+  protected:
+    void SetUp() override
+    {
+      if (sb::get_num_cuda_devices() == 0)
+      {
+        GTEST_SKIP() << "No CUDA devices available";
+      }
+    }
+
+    static sb::CudaBlockScheduler make_scheduler()
+    {
+      return sb::CudaBlockScheduler({
+          .nRows = 8, .nCols = 8,
+          .maxOutputElements = 16,
+          .nSplitsHint = 4,
+          .triangleMode = sb::BlockTriangleMode::Full,
+          .minBlockSide = 2
+      });
+    }
+  };
+
+  TEST_F(CudaBlockPipelineTest, ExecutesEveryBlock)
+  {
+    auto scheduler = make_scheduler();
+    ASSERT_GT(scheduler.blocks().size(), 1u);
+
+    tf::Executor gpuThreads(1);
+    CountingBlockOp op;
+    NullWriter writer;
+
+    sb::CudaBlockPipeline<float, CountingBlockOp, NullWriter> pipeline(
+        gpuThreads, op, scheduler, writer);
+    pipeline.execute(dim3(8, 8, 1));
+
+    EXPECT_EQ(op.calls.load(), static_cast<int>(scheduler.blocks().size()));
+  }
+
+  TEST_F(CudaBlockPipelineTest, ExceptionInBlockPropagatesFromExecute)
+  {
+    // Issue #188: the future from run() used to be discarded, so worker
+    // exceptions vanished and execute() returned normally.
+    auto scheduler = make_scheduler();
+
+    tf::Executor gpuThreads(1);
+    ThrowingBlockOp op;
+    NullWriter writer;
+
+    sb::CudaBlockPipeline<float, ThrowingBlockOp, NullWriter> pipeline(
+        gpuThreads, op, scheduler, writer);
+
+    EXPECT_THROW(pipeline.execute(dim3(8, 8, 1)), std::runtime_error);
+  }
+
+  TEST_F(CudaBlockPipelineTest, StopRequestSkipsRemainingBlocks)
+  {
+    // Issue #195: a stop request is polled per block; requested up front,
+    // no block may execute.
+    auto scheduler = make_scheduler();
+
+    tf::Executor gpuThreads(1);
+    CountingBlockOp op;
+    NullWriter writer;
+
+    sb::CudaBlockPipeline<float, CountingBlockOp, NullWriter> pipeline(
+        gpuThreads, op, scheduler, writer,
+        [](size_t) {}, [] { return true; });
+    pipeline.execute(dim3(8, 8, 1));
+
+    EXPECT_EQ(op.calls.load(), 0);
+  }
+
+  TEST_F(CudaBlockPipelineTest, CancelSkipsRemainingBlocks)
+  {
+    auto scheduler = make_scheduler();
+
+    tf::Executor gpuThreads(1);
+    CountingBlockOp op;
+    NullWriter writer;
+
+    sb::CudaBlockPipeline<float, CountingBlockOp, NullWriter> pipeline(
+        gpuThreads, op, scheduler, writer);
+    pipeline.cancel();
+    pipeline.execute(dim3(8, 8, 1));
+
+    EXPECT_EQ(op.calls.load(), 0);
+  }
+
+} // namespace
+
+#endif // BUILD_WITH_CUDA


### PR DESCRIPTION
Four CUDA runtime-robustness fixes from the bug scan, grouped because they touch the same pipeline files (`cuda_block_executor.cuh`, `pcf_block_op.cuh`) and dispatch sites. One commit per issue.

- **#189 (high) — multi-GPU data race**: `CudaOffsetDataManager::upload_subset` resized and wrote a shared `mutable` scratch vector from all GPU worker threads with no synchronization, producing torn offset tables (silently wrong distance matrices or OOB kernel reads) on 2+ GPU machines. The scratch buffer is now a local variable.
- **#188 (high) — CUDA errors silently swallowed**: `CudaBlockPipeline::execute` discarded the `tf::Future` from `run()` and used `wait_for_all()`, which does not rethrow task exceptions — a mid-computation CUDA failure (e.g. device OOM) returned a partially-zero matrix with no error. Now the future is retained and `.get()` rethrows into the outer task future that `StoppableTask::wait_for` already propagates to Python.
- **#187 (high) — segfault with zero usable CUDA devices**: all three CUDA dispatch sites (`pdist`/`cdist`/`l2_kernel`) now check `default_executor().cuda() != nullptr` and fall back to the CPU path instead of dereferencing null when the CUDA module loads but no device is usable at runtime (driver mismatch, `CUDA_VISIBLE_DEVICES=""`, ...).
- **#195 (medium) — Ctrl-C couldn't interrupt CUDA**: `CudaBlockPipeline::cancel()` existed but had no call sites, so `request_stop()` during a GPU `pdist` blocked until the whole matrix finished. The pipeline now polls a stop predicate per block; the CUDA tasks pass `StoppableTask::stop_requested()`, so interruption takes effect at block granularity like the CPU path.

Fixes #189, fixes #188, fixes #187, fixes #195

## Tests

New `test/test_cuda_block_pipeline.cu` (runs in the `BUILD_CUDA_TESTER` suite on the GPU runner), driving the real `CudaBlockPipeline` with stub BlockOps:

- an exception thrown inside `exec_block` propagates out of `execute()` (#188 — fails on the pre-fix `wait_for_all` code);
- a stop request skips all blocks (#195), and `cancel()` still does too;
- the normal path executes every scheduled block.

The #189 race itself has no deterministic single-run test (needs ≥2 GPUs plus a sanitizer); #187 needs an environment with a broken driver to trigger.

## Verification

No GPU or CUDA toolkit is available in the sandbox, so these changes were not executed on a device here: verified by syntax checks and review of the exception-propagation chain (per the contract documented in `task.hpp:78-96`, which the CPU path already relies on). Full CPU C++ + Python suites pass with these changes applied. The new `.cu` tests will exercise #188/#195 on the self-hosted GPU runner; a multi-GPU run for #189 before release is still recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017nGFonEvMk39UBWvqQS3HY