### PR TITLE
Align device-side rectangle iteration with the CPU path for custom integration bounds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -887,6 +887,7 @@ if (BUILD_TESTER)
         test/test_block_matrix_support.cu
         test/test_l1_dist.cu
         test/test_block_integrate.cu
+        test/test_block_integrate_bounds.cu
         test/test_norms.cu
         ${SB_TEST_SOURCES_COMMON}
     )

--- a/include/sbear/cuda/cuda_pcf_kernel.cuh
+++ b/include/sbear/cuda/cuda_pcf_kernel.cuh
@@ -31,8 +31,35 @@ namespace sb
       TriangleSkipMode skipMode;
     };
 
+    /// Index of the last breakpoint with t <= a (device analogue of the
+    /// host-side max_time_iterator_prior_to). Points are sorted by time.
+    template <typename Tt, typename Tv>
+    __device__ size_t cuda_max_time_index_prior_to(
+        const SimplePoint<Tt, Tv>* pts, size_t n, Tt a)
+    {
+      // upper_bound: first index with pts[i].t > a
+      size_t lo = 0;
+      size_t hi = n;
+      while (lo < hi)
+      {
+        size_t mid = lo + (hi - lo) / 2;
+        if (pts[mid].t <= a)
+        {
+          lo = mid + 1;
+        }
+        else
+        {
+          hi = mid;
+        }
+      }
+      return lo == 0 ? 0 : lo - 1;
+    }
+
     /// Walk two PCFs simultaneously through their breakpoints,
     /// calling cb(left, right, fValue, gValue) for each rectangle.
+    /// Mirrors the host-side iterate_rectangles (iterate_rectangles.hpp);
+    /// the two must stay in lockstep so CPU and GPU results agree for any
+    /// integration bounds [a, b].
     template<typename Tt, typename Tv, typename RectangleCallback>
     __device__ void cuda_pcf_iterate_rectangles(
         const SimplePoint<Tt, Tv>* rowPoints, size_t fOffset, size_t fsz,
@@ -45,11 +72,14 @@ namespace sb
       Tv fv;
       Tv gv;
 
-      size_t fi = 0;
-      size_t gi = 0;
-
       const SimplePoint<Tt, Tv>* fpts = rowPoints + fOffset;
       const SimplePoint<Tt, Tv>* gpts = colPoints + gOffset;
+
+      // Start at the last breakpoint <= a, like the CPU path -- starting at
+      // index 0 emits wrong values (and a negative-width leading rectangle)
+      // when there are breakpoints in (0, a].
+      size_t fi = cuda_max_time_index_prior_to(fpts, fsz, a);
+      size_t gi = cuda_max_time_index_prior_to(gpts, gsz, a);
 
       while (t < b)
       {
@@ -86,7 +116,9 @@ namespace sb
           }
         }
 
-        t = max(fpts[fi].t, gpts[gi].t);
+        // Clamp to b like the CPU path so the final rectangle does not
+        // integrate past a finite upper bound.
+        t = min(max(fpts[fi].t, gpts[gi].t), b);
         cb(tprev, t, fv, gv);
       }
     }

--- a/test/test_block_integrate_bounds.cu
+++ b/test/test_block_integrate_bounds.cu
@@ -1,0 +1,175 @@
+// Regression tests for issue #190: the device-side rectangle iteration must
+// agree with the CPU reference for non-default integration bounds [a, b].
+// Before the fix, the device walk started at the first breakpoint instead of
+// the last breakpoint <= a, and never clamped the final rectangle to b.
+
+#include <gtest/gtest.h>
+
+#include <sbear/functional/pcf.hpp>
+#include <sbear/distance_matrix.hpp>
+#include <sbear/task.hpp>
+#include <sbear/functional/operations.cuh>
+#include <sbear/algorithms/functional/matrix_integrate.hpp>
+
+#ifdef BUILD_WITH_CUDA
+#include <sbear/cuda/cuda_matrix_integrate_api.hpp>
+#endif
+
+#include <limits>
+#include <random>
+#include <utility>
+#include <vector>
+
+namespace
+{
+
+  template <typename T>
+  class BlockIntegrateBoundsTyped : public ::testing::Test
+  {
+  protected:
+    using Tv = T;
+    using PcfT = sb::Pcf<T, T>;
+    using PointT = sb::TimePoint<T, T>;
+
+    static double tol() { return std::is_same_v<T, float> ? 1e-4 : 1e-9; }
+
+    void SetUp() override
+    {
+#ifndef BUILD_WITH_CUDA
+      GTEST_SKIP() << "CUDA not available";
+#else
+      if (sb::get_num_cuda_devices() == 0)
+      {
+        GTEST_SKIP() << "No CUDA devices available";
+      }
+#endif
+    }
+
+    PcfT make_pcf(std::initializer_list<std::pair<Tv, Tv>> pts)
+    {
+      std::vector<PointT> points;
+      for (auto [t, v] : pts)
+      {
+        points.emplace_back(t, v);
+      }
+      return PcfT(std::move(points));
+    }
+
+    // Reference: the CPU integrate() with the same bounds and operation.
+    void expect_matches_cpu(const std::vector<PcfT>& pcfs, Tv a, Tv b)
+    {
+#ifdef BUILD_WITH_CUDA
+      auto op = sb::OperationL1Dist<Tv, Tv>{};
+
+      sb::DistanceMatrix<Tv> dm(pcfs.size());
+      auto task = sb::create_cuda_block_integrate_l1_task(dm, pcfs, a, b);
+      task->start_async(sb::default_executor());
+      task->future().get();
+
+      for (size_t i = 0; i < pcfs.size(); ++i)
+      {
+        for (size_t j = 0; j < i; ++j)
+        {
+          auto expected = op(sb::integrate<Tv, Tv>(pcfs[i], pcfs[j], op, a, b));
+          EXPECT_NEAR(dm(i, j), expected, tol())
+              << "pair (" << i << ", " << j << ") diverges for bounds [" << a << ", " << b << "]";
+        }
+      }
+#endif
+    }
+  };
+
+  using TestTypes = ::testing::Types<float, double>;
+  TYPED_TEST_SUITE(BlockIntegrateBoundsTyped, TestTypes);
+
+#ifdef BUILD_WITH_CUDA
+
+  TYPED_TEST(BlockIntegrateBoundsTyped, BreakpointsBeforeLowerBound)
+  {
+    // Breakpoints in (0, a]: the pre-fix device walk started at index 0 and
+    // emitted wrong values (and a negative-width leading rectangle).
+    using Tv = typename TestFixture::Tv;
+    using PcfT = typename TestFixture::PcfT;
+
+    std::vector<PcfT> pcfs;
+    pcfs.push_back(this->make_pcf({{0, 3}, {1, 5}, {2, 1}, {4, 0}}));
+    pcfs.push_back(this->make_pcf({{0, 1}, {1.5, 2}, {3, 4}, {5, 0}}));
+    pcfs.push_back(this->make_pcf({{0, 2}, {2.5, 3}, {6, 0}}));
+
+    this->expect_matches_cpu(pcfs, Tv(2), std::numeric_limits<Tv>::max());
+  }
+
+  TYPED_TEST(BlockIntegrateBoundsTyped, FiniteUpperBoundIsClamped)
+  {
+    // b inside the domain: the pre-fix device walk integrated the final
+    // rectangle past b.
+    using Tv = typename TestFixture::Tv;
+    using PcfT = typename TestFixture::PcfT;
+
+    std::vector<PcfT> pcfs;
+    pcfs.push_back(this->make_pcf({{0, 3}, {1, 5}, {4, 0}}));
+    pcfs.push_back(this->make_pcf({{0, 1}, {3, 4}, {5, 0}}));
+
+    this->expect_matches_cpu(pcfs, Tv(0), Tv(3.5));
+  }
+
+  TYPED_TEST(BlockIntegrateBoundsTyped, BothBoundsCustom)
+  {
+    using Tv = typename TestFixture::Tv;
+    using PcfT = typename TestFixture::PcfT;
+
+    std::vector<PcfT> pcfs;
+    pcfs.push_back(this->make_pcf({{0, 3}, {1, 5}, {2, 1}, {4, 0}}));
+    pcfs.push_back(this->make_pcf({{0, 1}, {1.5, 2}, {3, 4}, {5, 0}}));
+
+    this->expect_matches_cpu(pcfs, Tv(1.25), Tv(4.5));
+  }
+
+  TYPED_TEST(BlockIntegrateBoundsTyped, DefaultBoundsUnchanged)
+  {
+    using Tv = typename TestFixture::Tv;
+    using PcfT = typename TestFixture::PcfT;
+
+    std::vector<PcfT> pcfs;
+    pcfs.push_back(this->make_pcf({{0, 3}, {1, 0}}));
+    pcfs.push_back(this->make_pcf({{0, 1}, {2, 0}}));
+
+    this->expect_matches_cpu(pcfs, Tv(0), std::numeric_limits<Tv>::max());
+  }
+
+  TYPED_TEST(BlockIntegrateBoundsTyped, RandomizedAgainstCpu)
+  {
+    using Tv = typename TestFixture::Tv;
+    using PcfT = typename TestFixture::PcfT;
+    using PointT = typename TestFixture::PointT;
+
+    std::mt19937 rng(20260702);
+    std::uniform_int_distribution<int> szDist(1, 8);
+    std::uniform_real_distribution<double> dtDist(0.1, 2.0);
+    std::uniform_real_distribution<double> vDist(-4.0, 4.0);
+
+    std::vector<PcfT> pcfs;
+    for (int i = 0; i < 12; ++i)
+    {
+      std::vector<PointT> pts;
+      double t = 0.0;
+      int n = szDist(rng);
+      for (int k = 0; k < n; ++k)
+      {
+        pts.emplace_back(static_cast<Tv>(t), static_cast<Tv>(vDist(rng)));
+        t += dtDist(rng);
+      }
+      pcfs.emplace_back(std::move(pts));
+    }
+
+    for (auto [a, b] : {std::pair<Tv, Tv>{Tv(0.75), Tv(6)},
+                        std::pair<Tv, Tv>{Tv(2), Tv(3)},
+                        std::pair<Tv, Tv>{Tv(3.5), std::numeric_limits<Tv>::max()}})
+    {
+      this->expect_matches_cpu(pcfs, a, b);
+    }
+  }
+
+#endif // BUILD_WITH_CUDA
+
+} // namespace


### PR DESCRIPTION
Two latent divergences between `cuda_pcf_kernel.cuh` and the CPU reference (`iterate_rectangles.hpp`) when integrating over non-default bounds `[a, b]`:

- The device walk started at the first breakpoint instead of the last breakpoint ≤ `a`, emitting wrong values (and a negative-width leading rectangle) whenever breakpoints exist in `(0, a]`. It now starts via a device-side binary search mirroring `max_time_iterator_prior_to`.
- The rectangle end was never clamped to `b`, over-integrating past a finite upper bound. It now clamps exactly like the CPU path.

Currently latent: the Python bindings always pass `(0, max)`, and behavior for those default bounds is unchanged. But the public C++ factory API accepts arbitrary `a`/`b`, and any caller using it got GPU results silently diverging from the CPU.

Fixes #190

## Tests

New `test/test_block_integrate_bounds.cu` (runs in the `BUILD_CUDA_TESTER` suite on the GPU runner): compares the CUDA block pdist against the CPU `integrate()` reference for breakpoints before `a`, a finite `b` inside the domain, both bounds custom, the default bounds, and a randomized 12-PCF sweep over three bound combinations — in float32 and float64.

## Verification

No GPU is available in the sandbox, so additionally the device function was extracted verbatim from the header (with `__device__` defined away) and fuzz-compared against `sb::iterate_rectangles` on 20,000 random PCF pairs and bounds: the fixed code matches the CPU output exactly on every case, while the previous code diverged on ~10,600 of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017nGFonEvMk39UBWvqQS3HY