### PR TITLE
Fix size_t underflow in subdivide() for empty ranges

### DIFF
--- a/docs/internals/cuda_engine.rst
+++ b/docs/internals/cuda_engine.rst
@@ -93,6 +93,7 @@ The square root targets roughly square blocks, which is a good default for 2D CU
    subdivide(3, 10)  ->  [0,2], [3,5], [6,8], [9,9]
    subdivide(4, 8)   ->  [0,3], [4,7]
    subdivide(5, 3)   ->  [0,2]
+   subdivide(5, 0)   ->  (no bands)
 
 Row bands and column bands are computed independently: ``rowBands = subdivide(blockSide, nRows)``, ``colBands = subdivide(blockSide, nCols)``. This means rectangular matrices are handled naturally -- the row and column band counts can differ.
 

--- a/include/sbear/algorithms/functional/reduce.hpp
+++ b/include/sbear/algorithms/functional/reduce.hpp
@@ -10,6 +10,7 @@
 #include <numeric>
 #include <algorithm>
 #include <iterator>
+#include <stdexcept>
 
 #include <taskflow/taskflow.hpp>
 #include <taskflow/algorithm/reduce.hpp>
@@ -197,6 +198,14 @@ namespace sb
 
     auto chunksz = 2;
     auto sz = std::distance(begin, end);
+    if (sz == 0)
+    {
+      // A pairwise combine has no identity element, so an empty range cannot
+      // be reduced. Reject up front with a clean, catchable exception
+      // (pybind11 maps std::invalid_argument to a Python ValueError) --
+      // mirrors the empty-dimension error in matrix_reduce.hpp.
+      throw std::invalid_argument("Cannot reduce an empty range of PCFs");
+    }
     auto blocks = subdivide(chunkszFirst , sz);
 
     auto nAll = std::accumulate(begin, end, static_cast<size_t>(0ul), [](size_t n, const pcf_type& f){ return f.points().size() + n; });

--- a/include/sbear/algorithms/subdivide.hpp
+++ b/include/sbear/algorithms/subdivide.hpp
@@ -11,6 +11,13 @@ namespace sb
   subdivide(size_t blockSize, size_t nItems)
   {
     std::vector<std::pair<size_t, size_t>> boundaries;
+    if (nItems == 0)
+    {
+      // Blocks are inclusive [first, second] ranges, so there is no way to
+      // express an empty block -- and the clamp below would wrap
+      // nItems - 1 to SIZE_MAX. No items means no blocks.
+      return boundaries;
+    }
     for (size_t i = 0ul;; i += blockSize)
     {
       if (!boundaries.empty() && boundaries.back().second == nItems - 1)

--- a/test/test_parallel_reduce.cpp
+++ b/test/test_parallel_reduce.cpp
@@ -17,3 +17,22 @@ TEST(ParallelReduce, AddThreeFunctions)
 
   EXPECT_EQ(res, (pcfs[0] + pcfs[1] + pcfs[2]));
 }
+
+// Regression for issue #186: an empty range used to reach subdivide's
+// SIZE_MAX-wrapped block and read far out of bounds.
+TEST(ParallelReduce, EmptyRangeThrows)
+{
+  std::vector<sb::Pcf_f64> pcfs;
+
+  auto op = [](const typename sb::Pcf_f64::rectangle_type& rect) {
+    return rect.f_value + rect.g_value;
+  };
+
+  EXPECT_THROW(sb::parallel_reduce(pcfs.begin(), pcfs.end(), op), std::invalid_argument);
+}
+
+TEST(ParallelReduce, AverageOfEmptyVectorThrows)
+{
+  std::vector<sb::Pcf_f64> pcfs;
+  EXPECT_THROW(sb::average(pcfs), std::invalid_argument);
+}

--- a/test/test_subdivide.cpp
+++ b/test/test_subdivide.cpp
@@ -45,6 +45,17 @@ namespace
     }
   }
 
+  TEST(Subdivide, NoItems)
+  {
+    // Regression: nItems == 0 used to clamp the first block's end to
+    // nItems - 1, wrapping to SIZE_MAX (issue #186).
+    for (size_t bs = 1; bs <= 5; ++bs)
+    {
+      auto blocks = sb::subdivide(bs, 0);
+      EXPECT_TRUE(blocks.empty());
+    }
+  }
+
   TEST(Subdivide, SingleItem)
   {
     auto blocks = sb::subdivide(5, 1);


### PR DESCRIPTION
`subdivide(bs, 0)` clamped the first block's end to `nItems - 1`, which wraps to `SIZE_MAX`, so `parallel_reduce`/`average` on an empty range (reachable from Python via `cpp.Pcf_*.average([])` / `parallel_reduce([], cb)`) read ~2^64 elements out of bounds.

- `subdivide` now returns no blocks for zero items.
- `parallel_reduce` rejects an empty range with `std::invalid_argument` (a Python `ValueError`), mirroring the empty-dimension error `max_element` got for #25/#46 — a pairwise combine has no identity element. This also fixes `average`'s division by `fs.size() == 0` on the same path.

New regression tests: `Subdivide.NoItems`, `ParallelReduce.EmptyRangeThrows`, `ParallelReduce.AverageOfEmptyVectorThrows`; the `subdivide` example table in `docs/internals/cuda_engine.rst` documents the empty case.

Fixes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017nGFonEvMk39UBWvqQS3HY

---
_Generated by [Claude Code](https://claude.ai/code/session_017nGFonEvMk39UBWvqQS3HY)_