### PR TITLE
Return an empty result when evaluating a PCF tensor at an empty grid

### DIFF
--- a/include/sbear/algorithms/tensor_eval.hpp
+++ b/include/sbear/algorithms/tensor_eval.hpp
@@ -41,6 +41,13 @@ namespace sb
     std::vector<DomainT> domain_values;
     std::vector<std::vector<size_t>> domain_indices;
     auto n = domain.size();
+    if (n == 0)
+    {
+      // out already has shape elems.shape() + domain.shape(), i.e. zero
+      // entries -- nothing to evaluate. Bail before eval_elem indexes
+      // domain_indices[0] (numpy convention: empty grid -> empty result).
+      return;
+    }
     domain_values.reserve(n);
     domain_indices.reserve(n);
     walk(domain, [&](const std::vector<size_t>& idx) {

--- a/test/python/test_pcf_tensor_eval.py
+++ b/test/python/test_pcf_tensor_eval.py
@@ -130,6 +130,29 @@ class TestPcfTensorEvalArray:
         assert result.shape == (2, 2)
         npt.assert_array_almost_equal(result, [[1, 5], [3, 1]])
 
+    def test_empty_times_array(self, dtypes):
+        # Regression for issue #192: an empty evaluation grid used to hit
+        # undefined behavior instead of returning an empty result.
+        pcf_dtype, np_dtype = dtypes
+        X = make_1d_tensor(pcf_dtype, np_dtype)
+        result = X(np.array([], dtype=np_dtype))
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (2, 0)
+
+    def test_empty_times_list(self, dtypes):
+        pcf_dtype, np_dtype = dtypes
+        X = make_2d_tensor(pcf_dtype, np_dtype)
+        result = X([])
+        assert result.shape == (2, 2, 0)
+
+    @pytest.mark.parametrize("float_dtype", [np.float32, np.float64])
+    def test_empty_float_tensor_input(self, dtypes, float_dtype):
+        pcf_dtype, np_dtype = dtypes
+        X = make_1d_tensor(pcf_dtype, np_dtype)
+        t = sb.FloatTensor(np.array([], dtype=float_dtype))
+        result = X(t)
+        assert result.shape == (2, 0)
+
 
 class TestPcfTensorEvalParallel:
     """Verify that parallel tensor_eval produces correct results.


### PR DESCRIPTION
`tensor_eval`'s grid overload indexed `domain_indices[0]` without checking that the domain has any points, so `T(np.array([]))` was undefined behavior (executed once per tensor element). It now early-returns: the output already has shape `elems.shape() + domain.shape()`, i.e. zero entries — matching numpy's convention that an empty evaluation grid yields an empty result.

New Python regression tests cover the empty numpy-array, empty-list, and empty-`FloatTensor` inputs across all PCF dtypes (result shapes `(2, 0)` / `(2, 2, 0)`).

Fixes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017nGFonEvMk39UBWvqQS3HY

---
_Generated by [Claude Code](https://claude.ai/code/session_017nGFonEvMk39UBWvqQS3HY)_