### PR TITLE
Validate from_serial_content shapes and use signed stride arithmetic

### DIFF
--- a/src/python/functional/py_make_from_serial_content.cpp
+++ b/src/python/functional/py_make_from_serial_content.cpp
@@ -37,9 +37,19 @@ namespace sb_py
       throw std::runtime_error("content should have 2 dimensions (content has shape " + shape_to_string(content) + ").");
     }
 
+    if (content_buf.shape[1] != 2)
+    {
+      throw std::runtime_error("content should have 2 columns, [time, value] (content has shape " + shape_to_string(content) + ").");
+    }
+
     if (enumeration_buf.ndim < 2)
     {
       throw std::runtime_error("enumeration must have at least 2 dimensions");
+    }
+
+    if (enumeration_buf.shape[enumeration_buf.ndim - 1] != 2)
+    {
+      throw std::runtime_error("enumeration's last dimension should have size 2, [start, stop) (enumeration has shape " + shape_to_string(enumeration) + ").");
     }
 
     std::vector<size_t> targetShape(enumeration_buf.ndim - 1);
@@ -52,7 +62,9 @@ namespace sb_py
 
     sb::walk(target, [&target, &content, &enumeration](const std::vector<size_t>& idx) {
 
-      auto enumerationBaseOffset = std::inner_product(idx.begin(), idx.end(), enumeration.strides(), 0_uz);
+      // Signed accumulation: strides are negative for reversed views, and an
+      // unsigned division of the wrapped sum would produce a garbage offset.
+      auto enumerationBaseOffset = std::inner_product(idx.begin(), idx.end(), enumeration.strides(), py::ssize_t{0});
       enumerationBaseOffset /= enumeration.itemsize();
 
       auto* enumerationBuf = enumeration.unchecked().data();

--- a/src/python/py_np_support.hpp
+++ b/src/python/py_np_support.hpp
@@ -30,7 +30,9 @@ std::string shape_to_string(pybind11::array_t<T> arr)
 template <typename T>
 T& get_element(pybind11::array_t<T>& arr, const std::vector<pybind11::ssize_t>& idx)
 {
-  auto offset = std::inner_product(idx.begin(), idx.end(), arr.strides(), 0_uz);
+  // NumPy strides are signed (negative for reversed views), so the offset
+  // must accumulate and divide as a signed quantity.
+  auto offset = std::inner_product(idx.begin(), idx.end(), arr.strides(), pybind11::ssize_t{0});
   offset /= arr.itemsize();
   return *(static_cast<T*>(arr.request().ptr) + offset);
 }
@@ -55,12 +57,14 @@ public:
     return m_arr.shape(i);
   }
 
-  [[nodiscard]] std::vector<size_t> strides() const
+  [[nodiscard]] std::vector<pybind11::ssize_t> strides() const
   {
-    std::vector<size_t> s;
+    // Signed, like sb::Tensor::strides() -- numpy strides are negative for
+    // reversed views and must not be wrapped through size_t.
+    std::vector<pybind11::ssize_t> s;
     s.resize(m_arr.ndim());
     std::transform(m_arr.strides(), m_arr.strides() + m_arr.ndim(), s.begin(), [this](pybind11::ssize_t n) {
-      return static_cast<size_t>(n / m_arr.itemsize());
+      return n / m_arr.itemsize();
     });
     return s;
   }

--- a/test/python/test_from_serial_content.py
+++ b/test/python/test_from_serial_content.py
@@ -118,6 +118,64 @@ def test_fsc_negative_start_raises(dtype):
         sb.from_serial_content(content, enumeration)
 
 
+def test_fsc_content_wrong_trailing_dim_raises():
+    """content with anything but 2 columns must raise, not read past each row.
+
+    Regression for #193: content of shape (N, 1) read one element past every
+    row (heap over-read) instead of raising a shape error.
+    """
+    enumeration = np.array([[0, 2]], dtype=np.int64)
+    with pytest.raises(RuntimeError):
+        sb.from_serial_content(np.zeros((5, 1)), enumeration)
+    with pytest.raises(RuntimeError):
+        sb.from_serial_content(np.zeros((5, 3)), enumeration)
+
+
+def test_fsc_enumeration_wrong_trailing_dim_raises():
+    """enumeration whose last dim is not 2 must raise, not read stop OOB.
+
+    Regression for #193.
+    """
+    content = np.array([[0.0, 1.0], [2.0, 3.0]])
+    with pytest.raises(RuntimeError):
+        sb.from_serial_content(content, np.zeros((3, 1), dtype=np.int64))
+    with pytest.raises(RuntimeError):
+        sb.from_serial_content(content, np.zeros((3, 3), dtype=np.int64))
+
+
+def test_fsc_negative_stride_content():
+    """A reversed (negative-stride) content view must read the right rows.
+
+    Regression for #194: unsigned stride arithmetic wrapped the negative
+    stride to ~2^64, producing garbage offsets (OOB reads).
+    """
+    content = np.array([[0.0, 1.0], [0.0, 2.0], [0.0, 3.0], [0.0, 4.0]])
+    rev = content[::-1]
+    assert rev.strides[0] < 0
+    enumeration = np.array([[0, 1], [1, 2], [2, 3], [3, 4]], dtype=np.int64)
+
+    X = sb.from_serial_content(rev, enumeration)
+
+    for i in range(4):
+        assert X[i] == sb.Pcf(np.array([[0.0, 4.0 - i]]))
+
+
+def test_fsc_negative_stride_enumeration():
+    """A reversed (negative-stride) enumeration view must read the right items.
+
+    Regression for #194 (the enumeration base-offset accumulation).
+    """
+    content = np.array([[0.0, 10.0], [10.0, 20.0], [0.0, 50.0], [10.0, 60.0]])
+    enumeration = np.array([[0, 2], [2, 4]], dtype=np.int64)
+    rev = enumeration[::-1]
+    assert rev.strides[0] < 0
+
+    X = sb.from_serial_content(content, rev)
+
+    assert X[0] == sb.Pcf(content[2:4])
+    assert X[1] == sb.Pcf(content[0:2])
+
+
 def test_fsc_stop_equals_length_ok():
     """stop == content.shape(0) is in-bounds and must still succeed."""
     content = np.array([[0.0, 10.0], [10.0, 20.0], [20.0, 30.0]])


### PR DESCRIPTION
Two OOB-read classes in the serial-content path, grouped because they hit the same function and share regression tests:

- **#193** — trailing dimensions were never validated: `content` of shape `(N, 1)` read one element past every row, and an `enumeration` whose last dim ≠ 2 read `stop` out of bounds. Both now raise a clean shape error in the style of the existing ndim checks.
- **#194** — `get_element` and the enumeration base offset accumulated `idx · strides` with an unsigned initial value and divided in unsigned; numpy strides are signed, so a reversed (negative-stride) view wrapped to ~2^64 and produced garbage offsets. Accumulate and divide as signed, matching the already-correct `py_np_tensor_convert.cpp`. `NumpyTensor::strides()` is now signed too, like `sb::Tensor::strides()` (it had no consumers relying on the unsigned cast).

New Python regression tests: wrong trailing dims for both arrays raise, and reversed (negative-stride) `content`/`enumeration` views read the right elements.

Fixes #193, fixes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017nGFonEvMk39UBWvqQS3HY

---
_Generated by [Claude Code](https://claude.ai/code/session_017nGFonEvMk39UBWvqQS3HY)_