### PR TITLE
Fix axis position for advanced indices following a rank>1 index array

### DIFF
--- a/stablebear/_tensor_base.py
+++ b/stablebear/_tensor_base.py
@@ -362,13 +362,17 @@ class Tensor(ABC):
         basic = [slice(None) if isinstance(s, (BoolTensor, IntTensor)) else s
                  for s in entries]
         result = self._basic_getitem(basic, allow_scalar=False)
+        axis_shift = 0
         for orig_pos, idx in advanced:
             dims_dropped = sum(1 for j in range(orig_pos) if isinstance(entries[j], int))
-            axis = orig_pos - dims_dropped
+            axis = orig_pos - dims_dropped + axis_shift
             if isinstance(idx, BoolTensor):
                 result = self._to_py_tensor(result._data.axis_select(axis, idx._data))  # type: ignore[arg-type]
             else:
                 result = self._index_select_nd(result, axis, idx)
+                # A rank-r index array replaces the selected axis with r axes,
+                # so later advanced indices sit r - 1 positions further right.
+                axis_shift += max(idx.ndim, 1) - 1
         return result
 
     def _basic_getitem(self, entries, allow_scalar=True):

--- a/test/python/test_advanced_indexing.py
+++ b/test/python/test_advanced_indexing.py
@@ -210,6 +210,35 @@ class TestMultipleIntIndices:
         arr = np.arange(20, dtype=np.float32).reshape(4, 5)
         _assert_outer_index(arr, (np.array([1, 3]), slice(1, 4)))
 
+    def test_2d_index_array_then_1d(self):
+        # Regression for #182: a rank-2 index array inserts two output axes,
+        # so the next advanced index must shift right by one; it used to be
+        # applied to an axis of the first index array instead.
+        arr = np.arange(12, dtype=np.float32).reshape(3, 4)
+        result = np.asarray(_sb(arr)[np.array([[0, 1], [1, 0]]), np.array([1])])
+        expected = arr[np.array([[0, 1], [1, 0]])][:, :, [1]]
+        assert result.shape == (2, 2, 1)
+        np.testing.assert_array_equal(result, expected)
+
+    def test_two_2d_index_arrays_outer(self):
+        arr = np.arange(12, dtype=np.float32).reshape(3, 4)
+        rows = np.array([[0, 1], [2, 0]])
+        cols = np.array([[1, 3], [0, 2]])
+        result = np.asarray(_sb(arr)[rows, cols])
+        # Outer semantics: each rank-2 index contributes its own two axes.
+        expected = arr[rows][..., cols]
+        assert result.shape == (2, 2, 2, 2)
+        np.testing.assert_array_equal(result, expected)
+
+    def test_1d_then_2d_index_array(self):
+        arr = np.arange(12, dtype=np.float32).reshape(3, 4)
+        rows = np.array([2, 0])
+        cols = np.array([[1, 3], [0, 2]])
+        result = np.asarray(_sb(arr)[rows, cols])
+        expected = arr[rows][:, cols]
+        assert result.shape == (2, 2, 2)
+        np.testing.assert_array_equal(result, expected)
+
 
 class TestMixedBoolIntIndices:
     def test_bool_rows_int_cols(self):


### PR DESCRIPTION
`_getitem_entries` applied multiple advanced indices sequentially but never accounted for the output axes a rank-r index array inserts in place of the selected axis, so every subsequent advanced index was applied at a stale position — gathering from a dimension of the first index array instead of the intended axis (silently wrong data, or a spurious `IndexError` for larger index values). The accumulated axis shift (`rank - 1` per applied integer index array) is now tracked; the 1-D case is unaffected.

For `t` of shape `(3, 4)`: `t[np.array([[0, 1], [1, 0]]), np.array([1])]` now returns shape `(2, 2, 1)` with the correct outer-semantics values instead of `(2, 1, 4)` gathered from the wrong dimension.

New regression tests in `test_advanced_indexing.py` (rank-2 then rank-1, two rank-2 arrays, rank-1 then rank-2); the first two were verified to fail against the unfixed code.

Fixes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017nGFonEvMk39UBWvqQS3HY

---
_Generated by [Claude Code](https://claude.ai/code/session_017nGFonEvMk39UBWvqQS3HY)_