### PR TITLE
Fix _gpu_detect import path, DRM double-counting, and WSL2 detection

### DIFF
--- a/src/gpu_detect/gpu_detect.cpp
+++ b/src/gpu_detect/gpu_detect.cpp
@@ -8,6 +8,9 @@
 #include <dirent.h>
 #include <fstream>
 #include <sstream>
+#include <cctype>
+#include <cstring>
+#include <unistd.h>
 #elif defined(_WIN32)
 #include <windows.h>
 #include <dxgi.h>
@@ -30,7 +33,22 @@ struct GpuInfo
 
 #ifdef __linux__
 
-std::vector<GpuInfo> detect_gpus()
+// Each physical GPU exposes several /sys/class/drm nodes (cardN, renderDN,
+// and per-connector nodes that resolve to the same device). Count only the
+// cardN nodes so one GPU is reported once.
+bool is_drm_card_entry(const char* name)
+{
+  if (std::strncmp(name, "card", 4) != 0 || name[4] == '\0')
+    return false;
+  for (const char* p = name + 4; *p != '\0'; ++p)
+  {
+    if (!std::isdigit(static_cast<unsigned char>(*p)))
+      return false;
+  }
+  return true;
+}
+
+std::vector<GpuInfo> detect_gpus_drm()
 {
   std::vector<GpuInfo> gpus;
 
@@ -41,6 +59,9 @@ std::vector<GpuInfo> detect_gpus()
   const struct dirent* entry;
   while ((entry = readdir(drm)) != nullptr)
   {
+    if (!is_drm_card_entry(entry->d_name))
+      continue;
+
     std::string base = "/sys/class/drm/";
     base += entry->d_name;
     std::string device_path = base + "/device/";
@@ -95,6 +116,94 @@ std::vector<GpuInfo> detect_gpus()
 
   closedir(drm);
   return gpus;
+}
+
+// The driver's procfs has one directory per GPU. Covers slim containers
+// with no lspci and no NVIDIA PCI drm entries.
+std::vector<GpuInfo> detect_gpus_proc_driver()
+{
+  std::vector<GpuInfo> gpus;
+
+  DIR* dir = opendir("/proc/driver/nvidia/gpus");
+  if (!dir)
+    return gpus;
+
+  const struct dirent* entry;
+  while ((entry = readdir(dir)) != nullptr)
+  {
+    std::string name = entry->d_name;
+    if (name == "." || name == "..")
+      continue;
+
+    GpuInfo gpu;
+    gpu.vendor_id = NVIDIA_VENDOR_ID;
+    gpu.device_id = 0;
+    gpu.name = "NVIDIA GPU [" + name + "]";
+
+    std::ifstream info_file("/proc/driver/nvidia/gpus/" + name + "/information");
+    std::string line;
+    while (std::getline(info_file, line))
+    {
+      if (line.rfind("Model:", 0) == 0)
+      {
+        auto pos = line.find_first_not_of(" \t", 6);
+        if (pos != std::string::npos)
+        {
+          gpu.name = line.substr(pos);
+        }
+        break;
+      }
+    }
+
+    gpus.push_back(std::move(gpu));
+  }
+
+  closedir(dir);
+  return gpus;
+}
+
+// WSL2 exposes the GPU through /dev/dxg with no NVIDIA PCI drm nodes.
+// /dev/dxg alone could be any vendor, so require the WSL NVIDIA driver
+// libraries as well.
+std::vector<GpuInfo> detect_gpus_wsl()
+{
+  std::vector<GpuInfo> gpus;
+
+  if (access("/dev/dxg", F_OK) != 0)
+    return gpus;
+
+  const char* wsl_markers[] = {
+    "/usr/lib/wsl/lib/libcuda.so.1",
+    "/usr/lib/wsl/lib/libcuda.so",
+    "/usr/lib/wsl/lib/nvidia-smi",
+  };
+  for (const char* marker : wsl_markers)
+  {
+    if (access(marker, F_OK) == 0)
+    {
+      GpuInfo gpu;
+      gpu.vendor_id = NVIDIA_VENDOR_ID;
+      gpu.device_id = 0;
+      gpu.name = "NVIDIA GPU (WSL2)";
+      gpus.push_back(std::move(gpu));
+      break;
+    }
+  }
+
+  return gpus;
+}
+
+std::vector<GpuInfo> detect_gpus()
+{
+  auto gpus = detect_gpus_drm();
+  if (!gpus.empty())
+    return gpus;
+
+  gpus = detect_gpus_proc_driver();
+  if (!gpus.empty())
+    return gpus;
+
+  return detect_gpus_wsl();
 }
 
 #elif defined(_WIN32)

--- a/stablebear/gpu.py
+++ b/stablebear/gpu.py
@@ -5,7 +5,9 @@ falling back to a pure-Python implementation using subprocess.
 """
 
 try:
-    from _gpu_detect import detect_nvidia_gpus, has_nvidia_gpu, nvidia_gpu_count
+    # The extension is installed inside the package (site-packages/stablebear/),
+    # so it must be imported relatively; a top-level import never resolves.
+    from ._gpu_detect import detect_nvidia_gpus, has_nvidia_gpu, nvidia_gpu_count
 except ImportError:
     import os
     import platform
@@ -38,10 +40,14 @@ except ImportError:
         if gpus:
             return gpus
 
-        # Fallback: check sysfs for NVIDIA vendor ID (0x10de)
+        # Fallback: check sysfs for NVIDIA vendor ID (0x10de). Each physical
+        # GPU exposes several drm nodes (cardN, renderDN, connectors); count
+        # only the cardN nodes to avoid double-counting.
         drm_path = "/sys/class/drm"
         if os.path.isdir(drm_path):
             for entry in os.listdir(drm_path):
+                if not re.fullmatch(r"card\d+", entry):
+                    continue
                 vendor_file = os.path.join(drm_path, entry, "device", "vendor")
                 if os.path.isfile(vendor_file):
                     try:
@@ -51,6 +57,40 @@ except ImportError:
                             gpus.append({"name": "NVIDIA GPU"})
                     except OSError:
                         pass
+
+        if gpus:
+            return gpus
+
+        # Fallback: the driver's procfs (one directory per GPU). Covers slim
+        # containers without lspci or drm entries.
+        nvidia_proc = "/proc/driver/nvidia/gpus"
+        if os.path.isdir(nvidia_proc):
+            for entry in sorted(os.listdir(nvidia_proc)):
+                name = "NVIDIA GPU [" + entry + "]"
+                info_file = os.path.join(nvidia_proc, entry, "information")
+                try:
+                    with open(info_file) as f:
+                        for line in f:
+                            if line.startswith("Model:"):
+                                name = line[len("Model:"):].strip()
+                                break
+                except OSError:
+                    pass
+                gpus.append({"name": name})
+
+        if gpus:
+            return gpus
+
+        # Fallback: WSL2 exposes the GPU through /dev/dxg with no NVIDIA PCI
+        # drm nodes and no useful lspci. /dev/dxg alone could be any vendor,
+        # so require the WSL NVIDIA driver libraries as well.
+        if os.path.exists("/dev/dxg"):
+            wsl_lib = "/usr/lib/wsl/lib"
+            if any(
+                os.path.exists(os.path.join(wsl_lib, lib))
+                for lib in ("libcuda.so.1", "libcuda.so", "nvidia-smi")
+            ):
+                gpus.append({"name": "NVIDIA GPU (WSL2)"})
 
         return gpus
 


### PR DESCRIPTION
- `gpu.py` imported `_gpu_detect` as a top-level module, but CMake installs the extension inside the package (`site-packages/stablebear/`), so the import always failed and the compiled detector shipped in every wheel was dead code — the subprocess fallback silently took over, missing GPUs in slim containers with no `lspci`/drm entries. Now imported relatively (`from ._gpu_detect import ...`), keeping the fallback for source checkouts.
- The Linux DRM scan — in both the C++ module and the Python fallback — counted every `/sys/class/drm` node with an NVIDIA vendor id; each physical GPU exposes `cardN` plus `renderDN`/connector nodes, so counts were at least doubled. Both now count only `cardN` nodes.
- Neither path detected GPUs in slim containers or under WSL2 (`/dev/dxg`, no NVIDIA PCI drm nodes). Both now also enumerate `/proc/driver/nvidia/gpus` (one directory per GPU, with the model name from `information`) and detect WSL2 via `/dev/dxg` plus the WSL NVIDIA driver libraries (the extra check avoids false positives on non-NVIDIA WSL systems).

Fixes #173

## Verification

With this change the compiled module actually loads: `stablebear.gpu.detect_nvidia_gpus` resolves to the C++ extension and correctly reports zero GPUs in the (GPU-less) build container. The new procfs/WSL2 paths are review-verified; no NVIDIA hardware was available to exercise them end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017nGFonEvMk39UBWvqQS3HY

---
_Generated by [Claude Code](https://claude.ai/code/session_017nGFonEvMk39UBWvqQS3HY)_