### PR TITLE
Fix low-severity core defects: mean over empty dim, empty PCFs, negative barcode times, rank-0 size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -880,6 +880,7 @@ if (BUILD_TESTER)
       test/test_offset_data_manager.cpp
       test/test_walk_random.cpp
       test/test_subdivide.cpp
+      test/test_bugscan_core.cpp
   )
 
   if (BUILD_CUDA_TESTER)

--- a/include/sbear/algorithms/functional/matrix_reduce.hpp
+++ b/include/sbear/algorithms/functional/matrix_reduce.hpp
@@ -99,6 +99,16 @@ namespace sb
   template <typename PcfT>
   Tensor<PcfT> mean(const Tensor<PcfT>& in, size_t dim, Executor& exec = default_executor())
   {
+    // Same guard as max_element below: reducing a zero-length dimension would
+    // otherwise divide by zero and silently produce all-NaN PCFs.
+    check_reduce_dim(dim, in.shape().size());
+    if (in.shape()[dim] == 0)
+    {
+      std::ostringstream oss;
+      oss << "Cannot reduce an empty dimension: dimension " << dim << " has size 0";
+      throw std::invalid_argument(oss.str());
+    }
+
     auto ret = parallel_tensor_reduce(in, dim, [](const typename PcfT::rectangle_type& rect) {
       return rect.f_value + rect.g_value;
     }, exec);

--- a/include/sbear/functional/pcf.hpp
+++ b/include/sbear/functional/pcf.hpp
@@ -37,7 +37,13 @@ namespace sb
     explicit Pcf(std::vector<TimePoint<Tt, Tv>>&& pts)
       : m_points(std::move(pts))
     {
-
+      // evaluate and iterate_rectangles dereference the first point
+      // unconditionally; an empty PCF is UB there, so reject it here with a
+      // catchable error (e.g. a truncated file reaching io read_element).
+      if (m_points.empty())
+      {
+        throw std::invalid_argument("A PCF requires at least one point");
+      }
     }
 
     /// Converting constructor: convert from a Pcf with different precision.

--- a/include/sbear/io/pcf_io.hpp
+++ b/include/sbear/io/pcf_io.hpp
@@ -17,6 +17,18 @@ namespace sb::io::detail
   {
     using point_type = PcfT::point_type;
     auto pts = read_vector<point_type>(is);
+
+    // Validate the invariants downstream algorithms rely on, so a truncated
+    // or corrupted file yields a clean error instead of UB later. Emptiness
+    // is checked by the Pcf constructor itself.
+    for (size_t i = 1; i < pts.size(); ++i)
+    {
+      if (pts[i].t <= pts[i - 1].t)
+      {
+        throw std::runtime_error("Corrupt PCF data: breakpoint times are not strictly increasing");
+      }
+    }
+
     return PcfT(std::move(pts));
   }
 }

--- a/include/sbear/persistence/accumulated_persistence.hpp
+++ b/include/sbear/persistence/accumulated_persistence.hpp
@@ -5,6 +5,8 @@
 #include "barcode.hpp"
 #include "barcode_summary.hpp"
 
+#include <algorithm>
+
 namespace sb::ph
 {
   /**
@@ -71,7 +73,10 @@ namespace sb::ph
     std::vector<PcfPointT> points;
 
     T cumSum = T{0};
-    T lastMidpoint = T{0};
+    // Start at the earliest midpoint when it is negative (sublevel-set
+    // filtrations), mirroring barcode_to_betti_curve -- starting at 0 would
+    // emit an unsorted PCF.
+    T lastMidpoint = std::min(T{0}, entries.front().midpoint);
 
     for (auto const& entry : entries)
     {

--- a/include/sbear/persistence/betti_curve.hpp
+++ b/include/sbear/persistence/betti_curve.hpp
@@ -55,7 +55,10 @@ namespace sb::ph
     std::vector<PcfPointT> points;
 
     T count = 0;
-    T lastTime = T{0};
+    // Start at the earliest event when it is negative (sublevel-set
+    // filtrations); starting at 0 would emit a (0, 0) breakpoint followed by
+    // earlier times -- an unsorted PCF.
+    T lastTime = std::min(T{0}, events.front().time);
 
     for (auto const& event : events)
     {

--- a/include/sbear/tensor.tpp
+++ b/include/sbear/tensor.tpp
@@ -1186,10 +1186,10 @@ namespace sb
   template <typename T>
   [[nodiscard]] size_t Tensor<T>::size() const noexcept
   {
-    if (m_shape.empty())
-    {
-      return 0_uz;
-    }
+    // A rank-0 tensor holds exactly one element (numpy convention): walk()
+    // visits it and get_total_size() returns 1, so size() must agree --
+    // returning 0 made the randomized walk reserve too few RNG slots and
+    // progress/threshold logic miscount.
     return std::accumulate(m_shape.begin(), m_shape.end(), 1_uz, std::multiplies<size_t>());
   }
 

--- a/stablebear/reductions.py
+++ b/stablebear/reductions.py
@@ -71,6 +71,9 @@ def mean(fs: PcfContainerLike, dim: int = 0):
     ------
     IndexError
         If ``dim`` is out of range for the input tensor's number of dimensions.
+    ValueError
+        If the reduced dimension has size 0 (the mean of zero functions is
+        undefined).
     """
     backend, tensor = _resolve_pcf_inputs(_REDUCTIONS_BACKEND_MAP, fs)
     return _to_tensor(backend.mean(tensor._data, _resolve_dim(dim, tensor.ndim)))

--- a/test/python/test_bugscan_reductions.py
+++ b/test/python/test_bugscan_reductions.py
@@ -94,10 +94,11 @@ def test_max_time_empty_reduced_axis_raises_not_segfault():
     """max_time over a size-0 reduced axis must raise cleanly, never SIGSEGV.
 
     Issue #25 (bug scan): ``max_time`` segfaulted on an empty reduction
-    dimension while ``mean`` handled it. Resolved together with #46 —
-    ``max_element`` now rejects an empty reduction range with ``ValueError``
-    (``max`` has no identity over an empty range). ``mean`` still returns a
-    valid reduced tensor over the same empty axes, so the two stay consistent.
+    dimension. Resolved together with #46 — ``max_element`` now rejects an
+    empty reduction range with ``ValueError`` (``max`` has no identity over
+    an empty range). Issue #196: ``mean`` used to divide by zero on the same
+    input and silently return all-NaN PCFs; it now raises the same
+    ``ValueError``, so the two stay consistent.
     """
     # 1-D empty tensor reduced along its only (empty) axis.
     with pytest.raises(ValueError):
@@ -105,6 +106,8 @@ def test_max_time_empty_reduced_axis_raises_not_segfault():
     # Empty inner dimension of a higher-rank tensor.
     with pytest.raises(ValueError):
         sb.max_time(sb.zeros((3, 0)), dim=1)
-    # Contrast: mean returns a valid reduced tensor over the same empty axes.
-    assert sb.mean(sb.zeros((0,)), dim=0).shape == (1,)
-    assert sb.mean(sb.zeros((3, 0)), dim=1).shape == (3,)
+    # mean raises the same clean error instead of silently returning NaN PCFs.
+    with pytest.raises(ValueError):
+        sb.mean(sb.zeros((0,)), dim=0)
+    with pytest.raises(ValueError):
+        sb.mean(sb.zeros((3, 0)), dim=1)

--- a/test/test_bugscan_core.cpp
+++ b/test/test_bugscan_core.cpp
@@ -1,0 +1,115 @@
+// Regression tests for issue #196 (low-severity C++ core defects).
+
+#include <gtest/gtest.h>
+
+#include <sbear/functional/pcf.hpp>
+#include <sbear/algorithms/functional/matrix_reduce.hpp>
+#include <sbear/persistence/barcode.hpp>
+#include <sbear/persistence/betti_curve.hpp>
+#include <sbear/persistence/accumulated_persistence.hpp>
+#include <sbear/tensor.hpp>
+
+#include <stdexcept>
+#include <vector>
+
+namespace
+{
+
+  // --------------------------------------------------------------------------
+  // Empty PCFs are invalid: evaluate/iterate_rectangles dereference the first
+  // point unconditionally, so the constructor must reject an empty vector.
+  // --------------------------------------------------------------------------
+
+  TEST(BugscanCore, EmptyPcfConstructionThrows)
+  {
+    std::vector<sb::Pcf_f64::point_type> pts;
+    EXPECT_THROW(sb::Pcf_f64(std::move(pts)), std::invalid_argument);
+  }
+
+  // --------------------------------------------------------------------------
+  // mean() over a zero-length dimension used to divide by zero and silently
+  // return all-NaN PCFs; it must throw like max_element does.
+  // --------------------------------------------------------------------------
+
+  TEST(BugscanCore, MeanOverEmptyDimensionThrows)
+  {
+    sb::Tensor<sb::Pcf_f64> t({ 0, 3 });
+    EXPECT_THROW(sb::mean(t, 0), std::invalid_argument);
+
+    sb::Tensor<sb::Pcf_f64> t2({ 3, 0 });
+    EXPECT_THROW(sb::mean(t2, 1), std::invalid_argument);
+  }
+
+  TEST(BugscanCore, MeanOverNonEmptyDimensionStillWorks)
+  {
+    sb::Tensor<sb::Pcf_f64> t({ 2 });
+    t({ 0ul }) = sb::Pcf_f64(2.0);
+    t({ 1ul }) = sb::Pcf_f64(4.0);
+
+    auto m = sb::mean(t, 0);
+    ASSERT_EQ(m.size(), 1u);
+    EXPECT_EQ(m({ 0ul }).points()[0].v, 3.0);
+  }
+
+  // --------------------------------------------------------------------------
+  // Barcode summaries with negative event times (sublevel-set filtrations)
+  // used to emit a (0, 0) breakpoint followed by earlier negative times -- an
+  // unsorted PCF. The breakpoints must come out strictly increasing.
+  // --------------------------------------------------------------------------
+
+  template <typename PcfT>
+  void expect_strictly_increasing(const PcfT& f)
+  {
+    auto const& pts = f.points();
+    ASSERT_FALSE(pts.empty());
+    for (size_t i = 1; i < pts.size(); ++i)
+    {
+      EXPECT_LT(pts[i - 1].t, pts[i].t) << "breakpoints out of order at index " << i;
+    }
+  }
+
+  TEST(BugscanCore, BettiCurveWithNegativeBirthsIsSorted)
+  {
+    using T = sb::float64_t;
+    sb::ph::Barcode<T> barcode(std::vector<sb::ph::PersistencePair<T>>{
+        sb::ph::PersistencePair<T>(-2.0, -0.5),
+        sb::ph::PersistencePair<T>(-1.0, 1.0),
+        sb::ph::PersistencePair<T>(0.5, 2.0) });
+
+    auto f = sb::ph::barcode_to_betti_curve(barcode);
+    expect_strictly_increasing(f);
+
+    // Curve starts at the earliest birth, and the value on [0, inf) -- the
+    // PCF evaluation domain -- is correct instead of corrupt: at t = 0 the
+    // alive bars are (-1, 1) and (0.5 is not yet born), so count is 1.
+    EXPECT_EQ(f.points().front().t, -2.0);
+    EXPECT_EQ(f.evaluate(0.0), 1.0);  // bar (-1, 1) alive
+    EXPECT_EQ(f.evaluate(0.75), 2.0); // bars (-1, 1) and (0.5, 2) alive
+  }
+
+  TEST(BugscanCore, BettiCurveWithNonNegativeBirthsStillStartsAtZero)
+  {
+    using T = sb::float64_t;
+    sb::ph::Barcode<T> barcode(std::vector<sb::ph::PersistencePair<T>>{
+        sb::ph::PersistencePair<T>(1.0, 2.0) });
+
+    auto f = sb::ph::barcode_to_betti_curve(barcode);
+    expect_strictly_increasing(f);
+    EXPECT_EQ(f.points().front().t, 0.0);
+    EXPECT_EQ(f.evaluate(0.5), 0.0);
+    EXPECT_EQ(f.evaluate(1.5), 1.0);
+  }
+
+  TEST(BugscanCore, AccumulatedPersistenceWithNegativeMidpointsIsSorted)
+  {
+    using T = sb::float64_t;
+    sb::ph::Barcode<T> barcode(std::vector<sb::ph::PersistencePair<T>>{
+        sb::ph::PersistencePair<T>(-3.0, -1.0),
+        sb::ph::PersistencePair<T>(-1.0, 2.0) });
+
+    auto f = sb::ph::barcode_to_accumulated_persistence(barcode);
+    expect_strictly_increasing(f);
+    EXPECT_EQ(f.points().front().t, -2.0); // earliest midpoint
+  }
+
+} // namespace

--- a/test/test_tensor.cpp
+++ b/test/test_tensor.cpp
@@ -108,11 +108,22 @@ namespace
 
 // size()
 
-  TYPED_TEST(TensorTppTyped, SizeOfEmptyTensor)
+  TYPED_TEST(TensorTppTyped, SizeOfRankZeroTensorIsOne)
   {
+    // A rank-0 tensor holds exactly one element (numpy convention); size()
+    // must agree with walk() and get_total_size() (issue #196).
     using T = TypeParam;
     sb::Tensor<T> t;
+    EXPECT_EQ(t.size(), 1u);
+  }
+
+  TYPED_TEST(TensorTppTyped, SizeOfZeroExtentTensorIsZero)
+  {
+    using T = TypeParam;
+    sb::Tensor<T> t({ 0 });
     EXPECT_EQ(t.size(), 0u);
+    sb::Tensor<T> t2({ 3, 0 });
+    EXPECT_EQ(t2.size(), 0u);
   }
 
   TYPED_TEST(TensorTppTyped, Size1d)


### PR DESCRIPTION
The four core defects from #196, kept together as filed:

- **`mean()` over a zero-length dimension** divided by zero and silently returned all-NaN PCFs; it now raises the same clean `std::invalid_argument` (Python `ValueError`) as `max_element`. One pre-existing test asserted the silent behavior as an intentional contrast and was updated to expect the error; the `sb.mean` docstring documents it.
- **Empty PCFs** were accepted by `Pcf(std::vector&&)` but are UB in `evaluate`/`iterate_rectangles` (reachable from a truncated file via io `read_element`); the constructor now throws, and `read_element` additionally validates strictly-increasing breakpoint times so corrupted files fail cleanly.
- **Barcode summaries with negative event times** (sublevel-set filtrations): `barcode_to_betti_curve` and `barcode_to_accumulated_persistence` initialized their cursor at 0 and emitted a `(0, 0)` breakpoint followed by earlier negative ones — an unsorted PCF that corrupted later operations. They now start at the earliest event, producing sorted PCFs whose values on the `[0, inf)` evaluation domain are correct.
- **Rank-0 `Tensor::size()`** returned 0 while `walk()` visits one element and `get_total_size()` returns 1, breaking the randomized walk's RNG-slot reservation (documented stream non-overlap) and progress/threshold counts. It now returns 1 (numpy convention), matching the Python-facing `.size`, which already reported 1. The one C++ test asserting the old value was updated (zero-extent tensors still report 0).

New regression tests in `test/test_bugscan_core.cpp` cover all four.

Fixes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017nGFonEvMk39UBWvqQS3HY

---
_Generated by [Claude Code](https://claude.ai/code/session_017nGFonEvMk39UBWvqQS3HY)_