### PR TITLE
Register a no-op limit_gpus on CPU-only builds; fix buffer-protocol offset

### DIFF
--- a/src/python/py_tensor.hpp
+++ b/src/python/py_tensor.hpp
@@ -158,8 +158,11 @@ namespace sb_py
           std::transform(self.strides().begin(), self.strides().end(), strides.begin(),
               [](ptrdiff_t v) { return static_cast<pybind11::ssize_t>(v * sizeof(T)); });
 
+          // data() already includes the view offset; adding offset() again
+          // would read past the start of the view (latent until contiguous
+          // zero-copy views land, see tensor.tpp extract()).
           return pybind11::buffer_info(
-              static_cast<void*>(self.data() + self.offset()),
+              static_cast<void*>(self.data()),
               sizeof(T),
               pybind11::format_descriptor<T>::format(),
               self.rank(),

--- a/src/python/pymodule.cpp
+++ b/src/python/pymodule.cpp
@@ -145,6 +145,11 @@ PYBIND11_MODULE(SB_MODULE_NAME, m) {
   m.def("set_min_block_side", [](size_t n){ sb::settings().minBlockSide = n; });
 #ifdef BUILD_WITH_CUDA
   m.def("limit_gpus", [](size_t n){ sb::default_executor().limit_cuda_workers(n); });
+#else
+  // No-op on CPU-only builds, per the Python docstring ("only has an effect
+  // if compiled with GPU support") -- omitting it entirely made
+  // stablebear.system.limit_gpus raise AttributeError instead.
+  m.def("limit_gpus", [](size_t) { });
 #endif
   m.def("get_ngpus", &getNumGpus);
 

--- a/test/python/test_system_limits.py
+++ b/test/python/test_system_limits.py
@@ -1,0 +1,22 @@
+import pytest
+
+import stablebear as sb
+
+
+def test_limit_gpus_never_raises_attribute_error():
+    """Regression for #197: on CPU-only builds limit_gpus was not bound at
+    all, so the documented no-op was actually an AttributeError."""
+    try:
+        sb.system.limit_gpus(1)
+    except RuntimeError:
+        # A CUDA build may legitimately complain when fewer GPUs are
+        # available than requested; the point is the call must resolve.
+        pass
+
+
+def test_limit_cpus_roundtrip():
+    """limit_cpus is bound on every build and must accept a positive count."""
+    import os
+
+    sb.system.limit_cpus(2)
+    sb.system.limit_cpus(os.cpu_count() or 1)  # restore parallelism


### PR DESCRIPTION
- `limit_gpus` was only bound under `BUILD_WITH_CUDA`, so the documented "only has an effect if compiled with GPU support" behavior was actually an `AttributeError` on every CPU-only install (all macOS wheels, `BUILD_WITH_CUDA=0` builds). A no-op is now bound instead.
- The buffer protocol created views from `data() + offset()`, but `Tensor::data()` already includes the view offset — a latent double-offset that would read wrong memory the moment the planned contiguous zero-copy views land. Now just `data()`.

Fixes #197

## Tests

New `test/python/test_system_limits.py`: `limit_gpus(1)` must resolve on every build (an `AttributeError` fails the test; a `RuntimeError` from a CUDA build with fewer available GPUs is tolerated), plus a `limit_cpus` round-trip. Verified passing on the CPU-only build. The buffer-offset fix is latent (unreachable until zero-copy views land); existing numpy round-trip tests cover the current behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017nGFonEvMk39UBWvqQS3HY