### PR TITLE
Fix TestPyPI artifact name and pass CODECOV_TOKEN to reusable analysis

### DIFF
--- a/.github/workflows/analysis.yaml
+++ b/.github/workflows/analysis.yaml
@@ -11,6 +11,9 @@ on:
       use_github_runners:
         type: boolean
         default: false
+    secrets:
+      CODECOV_TOKEN:
+        required: false
 permissions:
   contents: write
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,3 +67,5 @@ jobs:
     uses: ./.github/workflows/analysis.yaml
     with:
       use_github_runners: true
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -66,6 +66,8 @@ jobs:
       contents: write
     uses: ./.github/workflows/analysis.yaml
     needs: check_version
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-pypitest.yaml
+++ b/.github/workflows/publish-pypitest.yaml
@@ -26,6 +26,8 @@ jobs:
       contents: write
     uses: ./.github/workflows/analysis.yaml
     needs: check_version
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   build:
     uses: ./.github/workflows/wheels.yaml
@@ -42,7 +44,7 @@ jobs:
       - name: Download wheels
         uses: actions/download-artifact@v8
         with:
-          name: cpu-wheels
+          name: wheels
           path: dist/
 
       - name: Compare wheels
@@ -66,7 +68,7 @@ jobs:
       - name: Download wheels
         uses: actions/download-artifact@v8
         with:
-          name: cpu-wheels
+          name: wheels
           path: dist/
 
       - name: Publish to TestPyPI


### PR DESCRIPTION
Grouped CI-workflow fixes:

- **#162** — `publish-pypitest.yaml`'s `compare` and `publish` jobs downloaded the nonexistent artifact `cpu-wheels` (a leftover from `wheels-tiny.yaml`), so a TestPyPI publish could never get past the build (~an hour of runner time, then "Artifact not found"). Both steps now download the merged `wheels` artifact that `wheels.yaml` uploads, matching what `publish-pypi.yaml` consumes.
- **#163** — `analysis.yaml` references `secrets.CODECOV_TOKEN` in three upload steps, but its `workflow_call` declared no secrets and no caller passed any, so every PR/publish pipeline uploaded coverage tokenless (rate-limited, silently unreliable). The secret is now declared (`required: false`) and passed explicitly from `ci.yaml`, `publish-pypi.yaml`, and `publish-pypitest.yaml`.

Fixes #162, fixes #163

YAML parses cleanly; the fixes will fully prove out on the next CI/publish run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017nGFonEvMk39UBWvqQS3HY

---
_Generated by [Claude Code](https://claude.ai/code/session_017nGFonEvMk39UBWvqQS3HY)_