### PR TITLE
Added type checks in plot_barcode.

### DIFF
--- a/stablebear/plotting.py
+++ b/stablebear/plotting.py
@@ -70,8 +70,9 @@ def plot_barcode(bc, ax=None, y_offset=0, **kwargs):
 
     Parameters
     ----------
-    bc : Barcode or BarcodeTensor
-        A single ``Barcode`` or a 1-D ``BarcodeTensor``. For a tensor,
+    bc : Barcode, BarcodeTensor or NumPy array
+        A single ``Barcode``, a 1-D ``BarcodeTensor`` or an (n, 2) NumPy array
+        of ``(birth, death)`` pairs. For a tensor,
         the barcodes are stacked vertically in order.
     ax : matplotlib axes, optional
         Axes to plot on. If ``None``, uses ``matplotlib.pyplot`` directly.
@@ -87,6 +88,15 @@ def plot_barcode(bc, ax=None, y_offset=0, **kwargs):
     -------
     int
         The next available y position (for stacking).
+
+    Raises
+    ------
+    TypeError
+        If ``bc`` is not a ``Barcode``, ``BarcodeTensor``, or ``numpy.ndarray``,
+        or if ``bc`` is a ``numpy.ndarray`` containing neither floats nor ints.
+    ValueError
+        If ``bc`` is a numpy array that is not of shape ``(n, 2)``, or a
+        ``BarcodeTensor`` with more than one dimension.
     """
     from matplotlib.collections import LineCollection
 
@@ -103,7 +113,17 @@ def plot_barcode(bc, ax=None, y_offset=0, **kwargs):
             y = plot_barcode(bc[i], ax=ax, y_offset=y, **kwargs)
         return y
 
+    if not isinstance(bc, (Barcode, np.ndarray)):
+        raise TypeError(f"Expected Barcode or numpy.ndarray; got {type(bc)}")
+
+    if isinstance(bc, np.ndarray):
+        if bc.ndim != 2 or bc.shape[1] != 2:
+            raise ValueError(f"Input should have shape (n, 2). Supplied input has shape {bc.shape}")
+        if not (np.issubdtype(bc.dtype, np.floating) or np.issubdtype(bc.dtype, np.integer)):
+            raise TypeError(f"Unsupported dtype {bc.dtype}; expected float or integer values")
+
     bars = np.asarray(bc)
+
     if len(bars) == 0:
         return y_offset
 

--- a/stablebear/plotting.py
+++ b/stablebear/plotting.py
@@ -100,8 +100,6 @@ def plot_barcode(bc, ax=None, y_offset=0, **kwargs):
     """
     from matplotlib.collections import LineCollection
 
-    ax = plt.gca() if ax is None else ax
-
     if isinstance(bc, BarcodeTensor):
         if len(bc.shape) != 1:
             squeezed = bc.squeeze()
@@ -121,6 +119,8 @@ def plot_barcode(bc, ax=None, y_offset=0, **kwargs):
             raise ValueError(f"Input should have shape (n, 2). Supplied input has shape {bc.shape}")
         if not (np.issubdtype(bc.dtype, np.floating) or np.issubdtype(bc.dtype, np.integer)):
             raise TypeError(f"Unsupported dtype {bc.dtype}; expected float or integer values")
+
+    ax = plt.gca() if ax is None else ax
 
     bars = np.asarray(bc)
 

--- a/test/python/test_plotting.py
+++ b/test/python/test_plotting.py
@@ -205,6 +205,24 @@ class TestPlotBarcode:
         with pytest.raises(ValueError, match="1-dimensional"):
             plot_barcode(bt2d, ax=ax)
 
+    def test_unsupported_type_raises(self, ax):
+        with pytest.raises(TypeError, match="Expected Barcode or numpy.ndarray"):
+            plot_barcode([[0, 1], [0.5, 2]], ax=ax)
+
+    def test_array_with_wrong_number_of_columns_raises(self, ax):
+        bars = np.zeros((3, 3), dtype=np.float64)
+        with pytest.raises(ValueError, match="Input should have shape"):
+            plot_barcode(bars, ax=ax)
+
+    def test_1d_array_raises(self, ax):
+        bars = np.array([0, 1, 2], dtype=np.float64)
+        with pytest.raises(ValueError, match="Input should have shape"):
+            plot_barcode(bars, ax=ax)
+
+    def test_array_with_unsupported_dtype_raises(self, ax):
+        bars = np.array([["a", "b"], ["c", "d"]])
+        with pytest.raises(TypeError, match="Unsupported dtype"):
+            plot_barcode(bars, ax=ax)
 
 if __name__ == "__main__":
     # Re-exec with the env var set so the backend selection at the top of


### PR DESCRIPTION
## Fix
**Python (`stablebear/plotting.py`)**

`plot_barcode` now accepts an `(n, 2) numpy.ndarray` of `(birth, death)` pairs directly, in addition to Barcode and 1-D BarcodeTensor. This mirrors the Barcode constructor, which already treats an (n, 2) array as a barcode.

Input validation added:

- `TypeError` if the input is not a `Barcode`, `BarcodeTensor`, or `numpy.ndarray`, or if an array's dtype is neither floating nor integer.

- `ValueError` if an array is not of shape `(n, 2)`. 

## Tests
Python `stablebear/test/python/test_plotting.py`. Added four tests checking the error messages for unsupported types/shapes.

Closes #159 .