### PR TITLE
Plot_barcode color fix

### DIFF
--- a/stablebear/plotting.py
+++ b/stablebear/plotting.py
@@ -61,6 +61,52 @@ def plot(f: PcfContainerLike, fmt="", ax=None, auto_label=False, max_time=None, 
         plot_single_(f, max_time)
 
 
+def _resolve_barcode_colors(n, color=None, cmap=None):
+    """Resolve a color specification into one color per barcode.
+
+    Parameters
+    ----------
+    n : int
+        number of barcodes to plot.
+    color : color-like object, list of color-like objects or None, optional
+        ``None`` yields matplotlib's property cycle, a single color is repeated
+        for all barcodes, and a sequence of colors is cycled across barcodes.
+    cmap : str or Colormap, optional
+        If passed, colors are sampled from the specified color map.
+        
+    Returns
+    -------
+    list of color-like objects
+        One color per barcode to be plotted.
+    
+    Raises
+    ------
+    ValueError
+        If color is not None, a color-like object or a list of color-like objects.
+    TypeError
+        If both color and cmap are passed
+    """
+    import matplotlib as mpl
+    from matplotlib.colors import is_color_like
+
+    if cmap is not None:
+        if color is not None:
+            raise TypeError("Pass either 'color' or 'cmap', not both")
+        return list(mpl.colormaps.get_cmap(cmap)(np.linspace(0, 1, n)))
+
+    if color is None:
+        cycle = plt.rcParams["axes.prop_cycle"].by_key().get("color", ["C0"])
+    elif is_color_like(color):
+        cycle = [color]
+    else:
+        cycle = list(color)
+        if len(cycle) == 0 or not all(is_color_like(c) for c in cycle):
+            raise ValueError(
+                f"'color' must be a color or a non-empty sequence of colors; got {color!r}"
+            )
+    return [cycle[i % len(cycle)] for i in range(n)]
+
+
 def plot_barcode(bc, ax=None, y_offset=0, **kwargs):
     """Plot a persistence barcode as horizontal line segments.
 
@@ -83,6 +129,14 @@ def plot_barcode(bc, ax=None, y_offset=0, **kwargs):
         Additional keyword arguments passed to
         ``matplotlib.collections.LineCollection``
         (e.g. ``color``, ``linewidth``, ``alpha``, ``label``).
+        When ``bc`` is a ``BarcodeTensor``, ``color`` may also be a sequence
+        of colors — one per barcode, cycled if there are more barcodes than
+        colors. If ``color`` is omitted, each barcode in a tensor gets the
+        next color from matplotlib's property cycle.
+        Alternatively, when ``bc`` is a ``BarcodeTensor``, ``cmap`` (a
+        colormap name or ``Colormap``) samples one color per barcode
+        evenly from the colormap; ``color`` and ``cmap`` are mutually
+        exclusive.
 
     Returns
     -------
@@ -93,12 +147,26 @@ def plot_barcode(bc, ax=None, y_offset=0, **kwargs):
     ------
     TypeError
         If ``bc`` is not a ``Barcode``, ``BarcodeTensor``, or ``numpy.ndarray``,
-        or if ``bc`` is a ``numpy.ndarray`` containing neither floats nor ints.
+        if ``bc`` is a ``numpy.ndarray`` containing neither floats nor ints,
+        if ``color`` is a sequence of colors while ``bc`` is a single ``Barcode`` or array,
+        if keyword ``colors`` is passed (instead of ``color``),
+        if both ``color`` and ``cmap`` are passed,
+        or if ``cmap`` is passed for a single ``Barcode`` or array.
     ValueError
-        If ``bc`` is a numpy array that is not of shape ``(n, 2)``, or a
-        ``BarcodeTensor`` with more than one dimension.
+        If ``bc`` is a numpy array that is not of shape ``(n, 2)``, a
+        ``BarcodeTensor`` with more than one dimension, or if ``color`` is
+        neither a color nor a non-empty sequence of colors.
     """
     from matplotlib.collections import LineCollection
+
+    if "colors" in kwargs:
+        # LineCollection would accept 'colors' (per-segment), but the bars are
+        # sorted internally so per-segment colors would land in scrambled
+        # order. Only 'color' has well-defined semantics here.
+        raise TypeError(
+            "plot_barcode() does not accept 'colors'; use 'color' "
+            "(a single color, or a sequence with one color per barcode)"
+        )
 
     if isinstance(bc, BarcodeTensor):
         if len(bc.shape) != 1:
@@ -106,13 +174,31 @@ def plot_barcode(bc, ax=None, y_offset=0, **kwargs):
             if len(squeezed.shape) != 1:
                 raise ValueError(f"Expected 1-dimensional tensor (got shape {bc.shape})")
             return plot_barcode(squeezed, ax=ax, y_offset=y_offset, **kwargs)
+        colors = _resolve_barcode_colors(bc.shape[0], kwargs.pop("color", None), kwargs.pop("cmap", None))
         y = y_offset
         for i in range(bc.shape[0]):
-            y = plot_barcode(bc[i], ax=ax, y_offset=y, **kwargs)
+            y = plot_barcode(bc[i], ax=ax, y_offset=y, color=colors[i], **kwargs)
         return y
 
     if not isinstance(bc, (Barcode, np.ndarray)):
         raise TypeError(f"Expected Barcode or numpy.ndarray; got {type(bc)}")
+
+    from matplotlib.colors import is_color_like
+
+    if "cmap" in kwargs:
+        raise TypeError(
+            "'cmap' is only supported for BarcodeTensor input; "
+            "use 'color' for a single barcode"
+        )
+
+    # A sequence of colors is only meaningful per barcode (tensor input);
+    # letting it through here would color individual bars in the internally
+    # sorted (i.e. scrambled) order via LineCollection.    
+    if "color" in kwargs and not is_color_like(kwargs["color"]):
+        raise TypeError(
+            "'color' must be a single color when plotting a single barcode; "
+            "a sequence of colors is only supported for BarcodeTensor input"
+        )
 
     if isinstance(bc, np.ndarray):
         if bc.ndim != 2 or bc.shape[1] != 2:
@@ -138,7 +224,6 @@ def plot_barcode(bc, ax=None, y_offset=0, **kwargs):
 
     defaults = {"linewidth": 1.5}
     defaults.update(kwargs)
-    color = defaults.get("color", None)
     lw = defaults.get("linewidth", 1.5)
 
     # Compute xmax for infinite bars (line segment extends to this point)
@@ -164,13 +249,14 @@ def plot_barcode(bc, ax=None, y_offset=0, **kwargs):
     if segments:
         lc = LineCollection(segments, **defaults)
         ax.add_collection(lc)
+        arrow_color = tuple(lc.get_colors()[0])
 
     # Add arrowheads for infinite bars
     for y in inf_y_positions:
         ax.annotate("",
             xy=(xmax, y),
             xytext=(xmax - (xmax * 0.02), y),
-            arrowprops=dict(arrowstyle="-|>", color=color, lw=lw))
+            arrowprops=dict(arrowstyle="-|>", color=arrow_color, lw=lw))
 
     ax.autoscale_view()
     ax.yaxis.set_ticks([])

--- a/stablebear/plotting.py
+++ b/stablebear/plotting.py
@@ -70,8 +70,9 @@ def plot_barcode(bc, ax=None, y_offset=0, **kwargs):
 
     Parameters
     ----------
-    bc : Barcode or BarcodeTensor
-        A single ``Barcode`` or a 1-D ``BarcodeTensor``. For a tensor,
+    bc : Barcode, BarcodeTensor or NumPy array
+        A single ``Barcode``, a 1-D ``BarcodeTensor`` or an (n, 2) NumPy array
+        of ``(birth, death)`` pairs. For a tensor,
         the barcodes are stacked vertically in order.
     ax : matplotlib axes, optional
         Axes to plot on. If ``None``, uses ``matplotlib.pyplot`` directly.
@@ -87,6 +88,15 @@ def plot_barcode(bc, ax=None, y_offset=0, **kwargs):
     -------
     int
         The next available y position (for stacking).
+
+    Raises
+    ------
+    TypeError
+        If ``bc`` is not a ``Barcode``, ``BarcodeTensor``, or ``numpy.ndarray``,
+        or if ``bc`` is a ``numpy.ndarray`` containing neither floats nor ints.
+    ValueError
+        If ``bc`` is a numpy array that is not of shape ``(n, 2)``, or a
+        ``BarcodeTensor`` with more than one dimension.
     """
     from matplotlib.collections import LineCollection
 
@@ -103,7 +113,17 @@ def plot_barcode(bc, ax=None, y_offset=0, **kwargs):
             y = plot_barcode(bc[i], ax=ax, y_offset=y, **kwargs)
         return y
 
+    if not isinstance(bc, (Barcode, np.ndarray)):
+        raise TypeError(f"Expected Barcode or numpy.ndarray; got {type(bc)}")
+
+    if isinstance(bc, np.ndarray):
+        if bc.ndim != 2 or bc.shape[1] != 2:
+            raise ValueError(f"Input should have shape (n, 2). Supplied input has shape {bc.shape}")
+        if not (np.issubdtype(bc.dtype, np.floating) or np.issubdtype(bc.dtype, np.integer)):
+            raise TypeError(f"Unsupported dtype {bc.dtype}; expected float or integer values")
+
     bars = np.asarray(bc)
+
     if len(bars) == 0:
         return y_offset
 

--- a/stablebear/plotting.py
+++ b/stablebear/plotting.py
@@ -73,16 +73,16 @@ def _resolve_barcode_colors(n, color=None, cmap=None):
         for all barcodes, and a sequence of colors is cycled across barcodes.
     cmap : str or Colormap, optional
         If passed, colors are sampled from the specified color map.
-        
+
     Returns
     -------
     list of color-like objects
         One color per barcode to be plotted.
-    
+
     Raises
     ------
     ValueError
-        If color is not None, a color-like object or a list of color-like objects.
+        If color is neither None, a color-like object, nor a list of color-like objects.
     TypeError
         If both color and cmap are passed
     """
@@ -129,14 +129,14 @@ def plot_barcode(bc, ax=None, y_offset=0, **kwargs):
         Additional keyword arguments passed to
         ``matplotlib.collections.LineCollection``
         (e.g. ``color``, ``linewidth``, ``alpha``, ``label``).
-        When ``bc`` is a ``BarcodeTensor``, ``color`` may also be a sequence
-        of colors — one per barcode, cycled if there are more barcodes than
-        colors. If ``color`` is omitted, each barcode in a tensor gets the
+        ``color`` may be a single color or a sequence of colors — one per
+        barcode, cycled if there are more barcodes than colors;
+        surplus colors are ignored; a single ``Barcode`` or array uses the
+        first color. Alternatively, ``cmap`` (a colormap name or ``Colormap``) samples
+        one color per barcode evenly from the colormap; a single ``Barcode``
+        or array gets the colormap's first color. ``color`` and ``cmap`` are mutually
+        exclusive. If both are omitted, each barcode in a tensor gets the
         next color from matplotlib's property cycle.
-        Alternatively, when ``bc`` is a ``BarcodeTensor``, ``cmap`` (a
-        colormap name or ``Colormap``) samples one color per barcode
-        evenly from the colormap; ``color`` and ``cmap`` are mutually
-        exclusive.
 
     Returns
     -------
@@ -148,10 +148,8 @@ def plot_barcode(bc, ax=None, y_offset=0, **kwargs):
     TypeError
         If ``bc`` is not a ``Barcode``, ``BarcodeTensor``, or ``numpy.ndarray``,
         if ``bc`` is a ``numpy.ndarray`` containing neither floats nor ints,
-        if ``color`` is a sequence of colors while ``bc`` is a single ``Barcode`` or array,
         if keyword ``colors`` is passed (instead of ``color``),
-        if both ``color`` and ``cmap`` are passed,
-        or if ``cmap`` is passed for a single ``Barcode`` or array.
+        or if both ``color`` and ``cmap`` are passed.
     ValueError
         If ``bc`` is a numpy array that is not of shape ``(n, 2)``, a
         ``BarcodeTensor`` with more than one dimension, or if ``color`` is
@@ -183,22 +181,12 @@ def plot_barcode(bc, ax=None, y_offset=0, **kwargs):
     if not isinstance(bc, (Barcode, np.ndarray)):
         raise TypeError(f"Expected Barcode or numpy.ndarray; got {type(bc)}")
 
-    from matplotlib.colors import is_color_like
-
-    if "cmap" in kwargs:
-        raise TypeError(
-            "'cmap' is only supported for BarcodeTensor input; "
-            "use 'color' for a single barcode"
-        )
-
-    # A sequence of colors is only meaningful per barcode (tensor input);
-    # letting it through here would color individual bars in the internally
-    # sorted (i.e. scrambled) order via LineCollection.    
-    if "color" in kwargs and not is_color_like(kwargs["color"]):
-        raise TypeError(
-            "'color' must be a single color when plotting a single barcode; "
-            "a sequence of colors is only supported for BarcodeTensor input"
-        )
+    # A single barcode behaves like a 1-element tensor for color purposes:
+    # a sequence of colors or a cmap resolves to its first color.
+    color = kwargs.pop("color", None)
+    cmap = kwargs.pop("cmap", None)
+    if color is not None or cmap is not None:
+        kwargs["color"] = _resolve_barcode_colors(1, color, cmap)[0]
 
     if isinstance(bc, np.ndarray):
         if bc.ndim != 2 or bc.shape[1] != 2:

--- a/stablebear/plotting.py
+++ b/stablebear/plotting.py
@@ -100,8 +100,6 @@ def plot_barcode(bc, ax=None, y_offset=0, **kwargs):
     """
     from matplotlib.collections import LineCollection
 
-    ax = plt.gca() if ax is None else ax
-
     if isinstance(bc, BarcodeTensor):
         if len(bc.shape) != 1:
             squeezed = bc.squeeze()
@@ -121,6 +119,8 @@ def plot_barcode(bc, ax=None, y_offset=0, **kwargs):
             raise ValueError(f"Input should have shape (n, 2). Supplied input has shape {bc.shape}")
         if not (np.issubdtype(bc.dtype, np.floating) or np.issubdtype(bc.dtype, np.integer)):
             raise TypeError(f"Unsupported dtype {bc.dtype}; expected float or integer values")
+
+    ax = plt.gca() if ax is None else ax
 
     bars = np.asarray(bc)
 

--- a/test/python/test_plotting.py
+++ b/test/python/test_plotting.py
@@ -205,6 +205,24 @@ class TestPlotBarcode:
         with pytest.raises(ValueError, match="1-dimensional"):
             plot_barcode(bt2d, ax=ax)
 
+    def test_unsupported_type_raises(self, ax):
+        with pytest.raises(TypeError, match="Expected Barcode or numpy.ndarray"):
+            plot_barcode([[0, 1], [0.5, 2]], ax=ax)
+
+    def test_array_with_wrong_number_of_columns_raises(self, ax):
+        bars = np.zeros((3, 3), dtype=np.float64)
+        with pytest.raises(ValueError, match="Input should have shape"):
+            plot_barcode(bars, ax=ax)
+
+    def test_1d_array_raises(self, ax):
+        bars = np.array([0, 1, 2], dtype=np.float64)
+        with pytest.raises(ValueError, match="Input should have shape"):
+            plot_barcode(bars, ax=ax)
+
+    def test_array_with_unsupported_dtype_raises(self, ax):
+        bars = np.array([["a", "b"], ["c", "d"]])
+        with pytest.raises(TypeError, match="Unsupported dtype"):
+            plot_barcode(bars, ax=ax)
 
 if __name__ == "__main__":
     # Re-exec with the env var set so the backend selection at the top of

--- a/test/python/test_plotting.py
+++ b/test/python/test_plotting.py
@@ -216,10 +216,21 @@ class TestPlotBarcode:
         for lc in ax.collections:
             assert tuple(lc.get_colors()[0]) == to_rgba("blue")
 
-    def test_color_list_on_single_barcode_raises(self, ax):
+    def test_color_list_on_single_barcode_uses_first(self, ax):
+        from matplotlib.colors import to_rgba
+
         bc = _make_barcode([[0, 1], [0.5, 2]])
-        with pytest.raises(TypeError, match="single color"):
-            plot_barcode(bc, ax=ax, color=["red", "green"])
+        plot_barcode(bc, ax=ax, color=["red", "green"])
+        assert tuple(ax.collections[0].get_colors()[0]) == to_rgba("red")
+
+    def test_tensor_surplus_colors_ignored(self, ax):
+        from matplotlib.colors import to_rgba
+
+        bc = _make_barcode([[0, 1]])
+        bt = BarcodeTensor([bc, bc])
+        plot_barcode(bt, ax=ax, color=["red", "green", "blue"])
+        assert tuple(ax.collections[0].get_colors()[0]) == to_rgba("red")
+        assert tuple(ax.collections[1].get_colors()[0]) == to_rgba("green")
 
     def test_colors_kwarg_rejected(self, ax):
         bc = _make_barcode([[0, 1]])
@@ -261,11 +272,16 @@ class TestPlotBarcode:
         bt = BarcodeTensor([bc, bc])
         with pytest.raises(TypeError, match="not both"):
             plot_barcode(bt, ax=ax, color="red", cmap="viridis")
+        with pytest.raises(TypeError, match="not both"):
+            plot_barcode(bc, ax=ax, color="red", cmap="viridis")
 
-    def test_cmap_on_single_barcode_raises(self, ax):
+    def test_cmap_on_single_barcode_uses_first_color(self, ax):
+        import matplotlib as mpl
+
         bc = _make_barcode([[0, 1]])
-        with pytest.raises(TypeError, match="only supported for BarcodeTensor"):
-            plot_barcode(bc, ax=ax, cmap="viridis")
+        plot_barcode(bc, ax=ax, cmap="viridis")
+        expected = mpl.colormaps.get_cmap("viridis")(0.0)
+        assert tuple(ax.collections[0].get_colors()[0]) == tuple(expected)
 
     def test_bars_sorted_by_birth_then_length_descending(self, ax):
         # Bars given out of order

--- a/test/python/test_plotting.py
+++ b/test/python/test_plotting.py
@@ -179,6 +179,94 @@ class TestPlotBarcode:
         y = plot_barcode(bt2d, ax=ax)
         assert y == 2
 
+    def test_tensor_default_colors_follow_prop_cycle(self, ax):
+        import matplotlib.pyplot as plt
+        from matplotlib.colors import to_rgba
+
+        bc = _make_barcode([[0, 1]])
+        bt = BarcodeTensor([bc, bc, bc])
+        plot_barcode(bt, ax=ax)
+        cycle = plt.rcParams["axes.prop_cycle"].by_key()["color"]
+        for i, lc in enumerate(ax.collections):
+            assert tuple(lc.get_colors()[0]) == to_rgba(cycle[i % len(cycle)])
+
+    def test_tensor_color_list_assigns_per_barcode(self, ax):
+        from matplotlib.colors import to_rgba
+
+        bc = _make_barcode([[0, 1], [0.5, 2]])
+        bt = BarcodeTensor([bc, bc])
+        plot_barcode(bt, ax=ax, color=["red", "green"])
+        assert tuple(ax.collections[0].get_colors()[0]) == to_rgba("red")
+        assert tuple(ax.collections[1].get_colors()[0]) == to_rgba("green")
+
+    def test_tensor_color_list_cycles_when_short(self, ax):
+        from matplotlib.colors import to_rgba
+
+        bc = _make_barcode([[0, 1]])
+        bt = BarcodeTensor([bc, bc, bc])
+        plot_barcode(bt, ax=ax, color=["red", "green"])
+        assert tuple(ax.collections[2].get_colors()[0]) == to_rgba("red")
+
+    def test_tensor_single_color_applies_to_all(self, ax):
+        from matplotlib.colors import to_rgba
+
+        bc = _make_barcode([[0, 1]])
+        bt = BarcodeTensor([bc, bc])
+        plot_barcode(bt, ax=ax, color="blue")
+        for lc in ax.collections:
+            assert tuple(lc.get_colors()[0]) == to_rgba("blue")
+
+    def test_color_list_on_single_barcode_raises(self, ax):
+        bc = _make_barcode([[0, 1], [0.5, 2]])
+        with pytest.raises(TypeError, match="single color"):
+            plot_barcode(bc, ax=ax, color=["red", "green"])
+
+    def test_colors_kwarg_rejected(self, ax):
+        bc = _make_barcode([[0, 1]])
+        with pytest.raises(TypeError, match="use 'color'"):
+            plot_barcode(bc, ax=ax, colors=["red"])
+        bt = BarcodeTensor([bc, bc])
+        with pytest.raises(TypeError, match="use 'color'"):
+            plot_barcode(bt, ax=ax, colors=["red", "green"])
+
+    def test_tensor_invalid_color_raises(self, ax):
+        bc = _make_barcode([[0, 1]])
+        bt = BarcodeTensor([bc, bc])
+        with pytest.raises(ValueError, match="sequence of colors"):
+            plot_barcode(bt, ax=ax, color=["red", "not-a-color"])
+        with pytest.raises(ValueError, match="sequence of colors"):
+            plot_barcode(bt, ax=ax, color=[])
+
+    def test_arrowhead_matches_bar_color_and_alpha(self, ax):
+        from matplotlib.colors import to_rgba
+
+        bc = _make_barcode([[0, 1], [0.5, np.inf]])
+        plot_barcode(bc, ax=ax, color="red", alpha=0.1)
+        bar_color = tuple(ax.collections[0].get_colors()[0])
+        assert bar_color == to_rgba("red", alpha=0.1)
+        assert tuple(ax.texts[0].arrow_patch.get_edgecolor()) == bar_color
+
+    def test_tensor_cmap_samples_colormap(self, ax):
+        import matplotlib as mpl
+
+        bc = _make_barcode([[0, 1]])
+        bt = BarcodeTensor([bc, bc, bc])
+        plot_barcode(bt, ax=ax, cmap="viridis")
+        expected = mpl.colormaps.get_cmap("viridis")(np.linspace(0, 1, 3))
+        for lc, exp in zip(ax.collections, expected):
+            assert tuple(lc.get_colors()[0]) == tuple(exp)
+
+    def test_color_and_cmap_together_raises(self, ax):
+        bc = _make_barcode([[0, 1]])
+        bt = BarcodeTensor([bc, bc])
+        with pytest.raises(TypeError, match="not both"):
+            plot_barcode(bt, ax=ax, color="red", cmap="viridis")
+
+    def test_cmap_on_single_barcode_raises(self, ax):
+        bc = _make_barcode([[0, 1]])
+        with pytest.raises(TypeError, match="only supported for BarcodeTensor"):
+            plot_barcode(bc, ax=ax, cmap="viridis")
+
     def test_bars_sorted_by_birth_then_length_descending(self, ax):
         # Bars given out of order
         bc = _make_barcode([[1, 3], [0, np.inf], [0, 2], [0, 5]])


### PR DESCRIPTION
## Fix
**Python (`stablebear/plotting.py`)**

The arrowheads drawn for infinite bars now match the bars exactly: they
inherit the resolved bar color, including `alpha` and the default-color
fallback, both of which were previously ignored.

## Features
`plot_barcode` now handles the kwargs `color` and `cmap` properly:

- `color` may be a single color or a sequence of colors — one per barcode,
  cycled if there are more barcodes than colors; surplus colors are ignored.
- `cmap` (a colormap name or `Colormap`) samples one color per barcode
  evenly from the colormap. `color` and `cmap` are mutually exclusive.
- If both are omitted, each barcode in a tensor gets the next color from
  matplotlib's property cycle.
- A single `Barcode`/NumPy array is treated like a 1-element tensor: a
  sequence or cmap resolves to its first color.
- The `colors` kwarg is rejected with a `TypeError` (bars are sorted
  internally, so per-segment colors would land in scrambled order).

Docstrings updated accordingly.

## Tests
**Python `test/python/test_plotting.py`**

Added tests checking the colors of plotted barcodes and the error messages for unsupported types/values.

Closes #160 .